### PR TITLE
feat(frontend): add static source page mock (landing UI)

### DIFF
--- a/mock_pages/ai_planner.html
+++ b/mock_pages/ai_planner.html
@@ -1,0 +1,352 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8"/>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+  <title>StudySync — AI Planner</title>
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet"/>
+  <link href="https://fonts.googleapis.com/css2?family=Sora:wght@300;400;600;700&family=DM+Sans:ital,wght@0,300;0,400;0,500;1,300&display=swap" rel="stylesheet"/>
+  <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" rel="stylesheet"/>
+  <style>
+    :root {
+      --navy: #0d1b2a; --card: #111f30; --sidebar: #0f1e2e;
+      --accent: #4f8ef7; --accent2: #7c5cfc; --green: #26d07c;
+      --text: #e8edf5; --muted: #6b839e; --border: rgba(255,255,255,0.07);
+    }
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+    body { font-family: 'DM Sans', sans-serif; background: var(--navy); color: var(--text); display: flex; height: 100vh; overflow: hidden; }
+
+    .sidebar { width: 220px; background: var(--sidebar); border-right: 1px solid var(--border); display: flex; flex-direction: column; padding: 24px 0; flex-shrink: 0; }
+    .brand { font-family: 'Sora', sans-serif; font-weight: 700; font-size: 1.2rem; color: var(--accent); padding: 0 22px; margin-bottom: 32px; display: flex; align-items: center; gap: 8px; }
+    .nav-section-label { font-size: 0.68rem; font-weight: 600; letter-spacing: 0.1em; color: var(--muted); text-transform: uppercase; padding: 0 22px; margin: 18px 0 8px; }
+    .nav-item { display: flex; align-items: center; gap: 10px; padding: 10px 22px; font-size: 0.88rem; font-weight: 500; color: var(--muted); cursor: pointer; transition: all 0.2s; text-decoration: none; }
+    .nav-item:hover, .nav-item.active { color: var(--text); background: rgba(79,142,247,0.1); }
+    .nav-item.active { color: var(--accent); border-right: 2px solid var(--accent); }
+    .nav-item i { width: 18px; text-align: center; font-size: 0.9rem; }
+    .sidebar-bottom { margin-top: auto; padding: 16px 22px; border-top: 1px solid var(--border); }
+    .avatar { width: 32px; height: 32px; border-radius: 50%; background: linear-gradient(135deg, var(--accent), var(--accent2)); display: flex; align-items: center; justify-content: center; font-size: 0.75rem; font-weight: 700; color: white; flex-shrink: 0; }
+
+    /* CHAT LAYOUT */
+    .main { flex: 1; display: flex; flex-direction: column; overflow: hidden; }
+    .topbar { padding: 16px 28px; border-bottom: 1px solid var(--border); display: flex; align-items: center; justify-content: space-between; background: var(--card); }
+    .ai-header { display: flex; align-items: center; gap: 12px; }
+    .ai-avatar { width: 38px; height: 38px; border-radius: 10px; background: linear-gradient(135deg, var(--accent), var(--accent2)); display: flex; align-items: center; justify-content: center; font-size: 1rem; }
+    .ai-name { font-family: 'Sora', sans-serif; font-weight: 700; font-size: 1rem; }
+    .ai-status { font-size: 0.75rem; color: var(--green); display: flex; align-items: center; gap: 5px; }
+    .status-dot { width: 7px; height: 7px; background: var(--green); border-radius: 50%; }
+
+    /* CHAT AREA */
+    .chat-body { flex: 1; overflow-y: auto; padding: 24px 28px; display: flex; flex-direction: column; gap: 20px; }
+    .chat-body::-webkit-scrollbar { width: 5px; }
+    .chat-body::-webkit-scrollbar-thumb { background: var(--border); border-radius: 3px; }
+
+    /* MESSAGES */
+    .msg { display: flex; gap: 12px; max-width: 75%; }
+    .msg.user { align-self: flex-end; flex-direction: row-reverse; }
+    .msg-avatar { width: 32px; height: 32px; border-radius: 8px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; font-size: 0.75rem; font-weight: 700; color: white; }
+    .msg-bubble {
+      background: var(--card); border: 1px solid var(--border);
+      border-radius: 14px 14px 14px 4px;
+      padding: 12px 16px; font-size: 0.88rem; line-height: 1.65;
+    }
+    .msg.user .msg-bubble {
+      background: linear-gradient(135deg, rgba(79,142,247,0.25), rgba(124,92,252,0.2));
+      border-color: rgba(79,142,247,0.3);
+      border-radius: 14px 14px 4px 14px;
+    }
+    .msg-time { font-size: 0.7rem; color: var(--muted); margin-top: 5px; }
+    .msg.user .msg-time { text-align: right; }
+
+    /* PLAN CARD inside AI message */
+    .plan-card {
+      background: rgba(255,255,255,0.04);
+      border: 1px solid var(--border);
+      border-radius: 10px; margin-top: 12px; overflow: hidden;
+    }
+    .plan-card-header {
+      background: rgba(79,142,247,0.1); padding: 9px 14px;
+      font-size: 0.78rem; font-weight: 700; color: var(--accent);
+      text-transform: uppercase; letter-spacing: 0.06em;
+      display: flex; align-items: center; gap: 6px;
+    }
+    .plan-row {
+      display: flex; align-items: center; gap: 10px;
+      padding: 9px 14px; border-bottom: 1px solid var(--border);
+      font-size: 0.82rem;
+    }
+    .plan-row:last-child { border-bottom: none; }
+    .plan-dot { width: 8px; height: 8px; border-radius: 50%; flex-shrink: 0; }
+    .plan-time { color: var(--muted); font-size: 0.78rem; min-width: 80px; }
+    .plan-subject { font-weight: 600; }
+    .plan-duration { margin-left: auto; color: var(--muted); font-size: 0.75rem; }
+
+    /* QUICK PROMPTS */
+    .quick-prompts { padding: 0 28px 14px; display: flex; gap: 8px; flex-wrap: wrap; }
+    .quick-btn {
+      background: rgba(255,255,255,0.04); border: 1px solid var(--border);
+      color: var(--muted); font-family: 'DM Sans', sans-serif;
+      font-size: 0.78rem; padding: 7px 14px; border-radius: 20px;
+      cursor: pointer; transition: all 0.2s; white-space: nowrap;
+    }
+    .quick-btn:hover { background: rgba(79,142,247,0.1); border-color: var(--accent); color: var(--accent); }
+
+    /* INPUT BAR */
+    .chat-input-wrap {
+      padding: 16px 28px;
+      border-top: 1px solid var(--border);
+      background: var(--card);
+    }
+    .input-row {
+      display: flex; align-items: flex-end; gap: 10px;
+      background: rgba(255,255,255,0.04); border: 1px solid var(--border);
+      border-radius: 14px; padding: 10px 14px;
+      transition: border-color 0.2s;
+    }
+    .input-row:focus-within { border-color: var(--accent); }
+    .chat-textarea {
+      flex: 1; background: transparent; border: none; outline: none;
+      color: var(--text); font-family: 'DM Sans', sans-serif;
+      font-size: 0.9rem; resize: none; min-height: 24px; max-height: 120px;
+      line-height: 1.5; padding: 0;
+    }
+    .chat-textarea::placeholder { color: var(--muted); }
+    .send-btn {
+      width: 36px; height: 36px; border-radius: 9px; flex-shrink: 0;
+      background: var(--accent); border: none; color: white;
+      display: flex; align-items: center; justify-content: center;
+      cursor: pointer; transition: opacity 0.2s; font-size: 0.85rem;
+    }
+    .send-btn:hover { opacity: 0.85; }
+    .input-hint { font-size: 0.72rem; color: var(--muted); text-align: center; margin-top: 8px; }
+
+    /* typing animation */
+    .typing { display: flex; align-items: center; gap: 4px; padding: 4px 0; }
+    .typing span { width: 7px; height: 7px; border-radius: 50%; background: var(--muted); display: inline-block; animation: bounce 1.2s infinite; }
+    .typing span:nth-child(2) { animation-delay: 0.2s; }
+    .typing span:nth-child(3) { animation-delay: 0.4s; }
+    @keyframes bounce { 0%,80%,100%{transform:translateY(0)} 40%{transform:translateY(-6px)} }
+  </style>
+</head>
+<body>
+
+<!-- SIDEBAR -->
+<nav class="sidebar">
+  <div class="brand"><i class="fas fa-calendar-alt"></i> StudySync</div>
+  <span class="nav-section-label">Main</span>
+  <a href="timetable.html" class="nav-item"><i class="fas fa-calendar-week"></i> Timetable</a>
+  <a href="ai_planner.html" class="nav-item active"><i class="fas fa-robot"></i> AI Planner</a>
+  <a href="group.html" class="nav-item"><i class="fas fa-users"></i> My Group</a>
+  <span class="nav-section-label">Personal</span>
+  <a href="#" class="nav-item"><i class="fas fa-book-open"></i> Courses</a>
+  <a href="exam_detail.html" class="nav-item"><i class="fas fa-file-alt"></i> Exams &amp; Tasks</a>
+  <a href="#" class="nav-item"><i class="fas fa-bell"></i> Reminders</a>
+  <span class="nav-section-label">Settings</span>
+  <a href="#" class="nav-item"><i class="fas fa-cog"></i> Preferences</a>
+  <div class="sidebar-bottom">
+    <div style="display:flex;align-items:center;gap:10px">
+      <div class="avatar">JS</div>
+      <div>
+        <div style="font-size:0.82rem;font-weight:600;">Jane Smith</div>
+        <div style="font-size:0.72rem;color:var(--muted);">23456789</div>
+      </div>
+    </div>
+  </div>
+</nav>
+
+<!-- MAIN CHAT -->
+<div class="main">
+  <div class="topbar">
+    <div class="ai-header">
+      <div class="ai-avatar"><i class="fas fa-robot" style="color:white;font-size:1rem"></i></div>
+      <div>
+        <div class="ai-name">StudySync AI</div>
+        <div class="ai-status"><span class="status-dot"></span> Online · Powered by Claude</div>
+      </div>
+    </div>
+    <div style="display:flex;gap:8px;">
+      <button style="background:rgba(255,255,255,0.05);border:1px solid var(--border);color:var(--muted);font-size:0.8rem;padding:6px 12px;border-radius:8px;cursor:pointer;">
+        <i class="fas fa-trash-alt"></i> Clear
+      </button>
+      <button style="background:rgba(255,255,255,0.05);border:1px solid var(--border);color:var(--muted);font-size:0.8rem;padding:6px 12px;border-radius:8px;cursor:pointer;">
+        <i class="fas fa-history"></i> History
+      </button>
+    </div>
+  </div>
+
+  <!-- MESSAGES -->
+  <div class="chat-body" id="chatBody">
+
+    <!-- AI greeting -->
+    <div class="msg">
+      <div class="msg-avatar" style="background:linear-gradient(135deg,var(--accent),var(--accent2))"><i class="fas fa-robot"></i></div>
+      <div>
+        <div class="msg-bubble">
+          👋 Hi Jane! I'm your AI study planner. I can see you have a <strong>CITS3403 Mid-semester Test in 2 hours 35 minutes</strong>.<br/><br/>
+          I've looked at your revision progress and your timetable. How can I help you right now?
+        </div>
+        <div class="msg-time">Today, 7:22 AM</div>
+      </div>
+    </div>
+
+    <!-- User message -->
+    <div class="msg user">
+      <div class="msg-avatar" style="background:linear-gradient(135deg,#ff6b35,#ffc94a)">JS</div>
+      <div>
+        <div class="msg-bubble">
+          I still haven't revised Flask and SQLAlchemy. Can you make me a quick study plan for the next 2 hours?
+        </div>
+        <div class="msg-time">Today, 7:24 AM</div>
+      </div>
+    </div>
+
+    <!-- AI plan response -->
+    <div class="msg">
+      <div class="msg-avatar" style="background:linear-gradient(135deg,var(--accent),var(--accent2))"><i class="fas fa-robot"></i></div>
+      <div>
+        <div class="msg-bubble">
+          Sure! Here's a focused 2-hour plan to maximise your score on the weak areas. I've kept some buffer time before the exam. 🎯
+
+          <div class="plan-card">
+            <div class="plan-card-header"><i class="fas fa-calendar-check"></i> Study Plan — Next 2 Hours</div>
+            <div class="plan-row">
+              <div class="plan-dot" style="background:#4f8ef7"></div>
+              <div class="plan-time">7:25 – 8:05</div>
+              <div class="plan-subject">Flask Routes &amp; Jinja Templates</div>
+              <div class="plan-duration">40 min</div>
+            </div>
+            <div class="plan-row">
+              <div class="plan-dot" style="background:#ffc94a"></div>
+              <div class="plan-time">8:05 – 8:10</div>
+              <div class="plan-subject">☕ Short break</div>
+              <div class="plan-duration">5 min</div>
+            </div>
+            <div class="plan-row">
+              <div class="plan-dot" style="background:#7c5cfc"></div>
+              <div class="plan-time">8:10 – 8:50</div>
+              <div class="plan-subject">SQLAlchemy Models &amp; Queries</div>
+              <div class="plan-duration">40 min</div>
+            </div>
+            <div class="plan-row">
+              <div class="plan-dot" style="background:#26d07c"></div>
+              <div class="plan-time">8:50 – 9:25</div>
+              <div class="plan-subject">Quick review + past questions</div>
+              <div class="plan-duration">35 min</div>
+            </div>
+            <div class="plan-row">
+              <div class="plan-dot" style="background:#ff5555"></div>
+              <div class="plan-time">9:25 – 9:55</div>
+              <div class="plan-subject">🚶 Walk to exam room, settle in</div>
+              <div class="plan-duration">30 min</div>
+            </div>
+          </div>
+
+          Want me to add these as timed reminders to your timetable?
+        </div>
+        <div class="msg-time">Today, 7:24 AM</div>
+      </div>
+    </div>
+
+    <!-- User message 2 -->
+    <div class="msg user">
+      <div class="msg-avatar" style="background:linear-gradient(135deg,#ff6b35,#ffc94a)">JS</div>
+      <div>
+        <div class="msg-bubble">Yes please add them! Also give me the key Flask concepts I need to know in 5 bullet points</div>
+        <div class="msg-time">Today, 7:25 AM</div>
+      </div>
+    </div>
+
+    <!-- AI response 2 -->
+    <div class="msg">
+      <div class="msg-avatar" style="background:linear-gradient(135deg,var(--accent),var(--accent2))"><i class="fas fa-robot"></i></div>
+      <div>
+        <div class="msg-bubble">
+          ✅ <strong>Reminders added to your timetable!</strong><br/><br/>
+          Here are the 5 most important Flask concepts for today:<br/><br/>
+          <strong>1. Routes &amp; URL Building</strong> — Use <code style="background:rgba(255,255,255,0.1);padding:1px 5px;border-radius:4px">@app.route('/path')</code> and <code style="background:rgba(255,255,255,0.1);padding:1px 5px;border-radius:4px">url_for()</code> to build URLs, never hardcode them.<br/><br/>
+          <strong>2. Request &amp; Response</strong> — <code style="background:rgba(255,255,255,0.1);padding:1px 5px;border-radius:4px">request.form</code>, <code style="background:rgba(255,255,255,0.1);padding:1px 5px;border-radius:4px">request.args</code>, <code style="background:rgba(255,255,255,0.1);padding:1px 5px;border-radius:4px">request.json</code> — know the difference.<br/><br/>
+          <strong>3. Jinja2 Templates</strong> — <code style="background:rgba(255,255,255,0.1);padding:1px 5px;border-radius:4px">{{ var }}</code> to display, <code style="background:rgba(255,255,255,0.1);padding:1px 5px;border-radius:4px">{% for %}</code> to loop, <code style="background:rgba(255,255,255,0.1);padding:1px 5px;border-radius:4px">{% block %}</code> for inheritance.<br/><br/>
+          <strong>4. SQLAlchemy Models</strong> — Define models as Python classes, use <code style="background:rgba(255,255,255,0.1);padding:1px 5px;border-radius:4px">db.session.add()</code> and <code style="background:rgba(255,255,255,0.1);padding:1px 5px;border-radius:4px">db.session.commit()</code>.<br/><br/>
+          <strong>5. Flask-Login</strong> — <code style="background:rgba(255,255,255,0.1);padding:1px 5px;border-radius:4px">@login_required</code> decorator, <code style="background:rgba(255,255,255,0.1);padding:1px 5px;border-radius:4px">current_user</code> object, <code style="background:rgba(255,255,255,0.1);padding:1px 5px;border-radius:4px">login_user()</code> / <code style="background:rgba(255,255,255,0.1);padding:1px 5px;border-radius:4px">logout_user()</code>.
+        </div>
+        <div class="msg-time">Today, 7:25 AM</div>
+      </div>
+    </div>
+
+    <!-- Typing indicator (shown at bottom) -->
+    <div class="msg" id="typingIndicator" style="display:none">
+      <div class="msg-avatar" style="background:linear-gradient(135deg,var(--accent),var(--accent2))"><i class="fas fa-robot"></i></div>
+      <div class="msg-bubble"><div class="typing"><span></span><span></span><span></span></div></div>
+    </div>
+
+  </div><!-- end chat-body -->
+
+  <!-- QUICK PROMPTS -->
+  <div class="quick-prompts">
+    <button class="quick-btn" onclick="sendQuick('What topics are most likely in the exam?')">📊 Likely exam topics</button>
+    <button class="quick-btn" onclick="sendQuick('Explain SQLAlchemy relationships simply')">🔗 SQLAlchemy relationships</button>
+    <button class="quick-btn" onclick="sendQuick('Give me a practice question')">📝 Practice question</button>
+    <button class="quick-btn" onclick="sendQuick('How is my group doing on their revision?')">👥 Group progress</button>
+    <button class="quick-btn" onclick="sendQuick('Reschedule my study plan')">🔄 Reschedule plan</button>
+  </div>
+
+  <!-- INPUT -->
+  <div class="chat-input-wrap">
+    <div class="input-row">
+      <textarea class="chat-textarea" id="chatInput" placeholder="Ask about your timetable, exams, or study plan…" rows="1"
+        onkeydown="if(event.key==='Enter'&&!event.shiftKey){event.preventDefault();sendMessage()}"
+        oninput="this.style.height='auto';this.style.height=this.scrollHeight+'px'"></textarea>
+      <button class="send-btn" onclick="sendMessage()"><i class="fas fa-paper-plane"></i></button>
+    </div>
+    <div class="input-hint">StudySync AI can see your timetable and exam schedule · Press Enter to send</div>
+  </div>
+</div>
+
+<script>
+function sendQuick(text) {
+  document.getElementById('chatInput').value = text;
+  sendMessage();
+}
+
+function sendMessage() {
+  const input = document.getElementById('chatInput');
+  const text = input.value.trim();
+  if (!text) return;
+
+  const chatBody = document.getElementById('chatBody');
+  const typingEl = document.getElementById('typingIndicator');
+
+  // Add user message
+  const userMsg = document.createElement('div');
+  userMsg.className = 'msg user';
+  userMsg.innerHTML = `
+    <div class="msg-avatar" style="background:linear-gradient(135deg,#ff6b35,#ffc94a)">JS</div>
+    <div>
+      <div class="msg-bubble">${text}</div>
+      <div class="msg-time">Just now</div>
+    </div>`;
+  chatBody.insertBefore(userMsg, typingEl);
+  input.value = '';
+  input.style.height = 'auto';
+
+  // Show typing
+  typingEl.style.display = 'flex';
+  chatBody.scrollTop = chatBody.scrollHeight;
+
+  // Simulate AI response
+  setTimeout(() => {
+    typingEl.style.display = 'none';
+    const aiMsg = document.createElement('div');
+    aiMsg.className = 'msg';
+    aiMsg.innerHTML = `
+      <div class="msg-avatar" style="background:linear-gradient(135deg,var(--accent),var(--accent2))"><i class="fas fa-robot"></i></div>
+      <div>
+        <div class="msg-bubble">That's a great question! In a real implementation, this would call the Claude API with your full timetable context. For now, this is a static prototype demonstrating the UI. 🚀</div>
+        <div class="msg-time">Just now</div>
+      </div>`;
+    chatBody.insertBefore(aiMsg, typingEl);
+    chatBody.scrollTop = chatBody.scrollHeight;
+  }, 1500);
+}
+</script>
+</body>
+</html>

--- a/mock_pages/exam_detail.html
+++ b/mock_pages/exam_detail.html
@@ -1,0 +1,367 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8"/>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+  <title>StudySync — Exam Detail</title>
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet"/>
+  <link href="https://fonts.googleapis.com/css2?family=Sora:wght@300;400;600;700&family=DM+Sans:ital,wght@0,300;0,400;0,500;1,300&display=swap" rel="stylesheet"/>
+  <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" rel="stylesheet"/>
+  <style>
+    :root {
+      --navy: #0d1b2a; --navy2: #1b2d42; --card: #111f30; --sidebar: #0f1e2e;
+      --accent: #4f8ef7; --accent2: #7c5cfc; --orange: #ff6b35; --pink: #e040fb;
+      --green: #26d07c; --yellow: #ffc94a; --red: #ff5555;
+      --text: #e8edf5; --muted: #6b839e; --border: rgba(255,255,255,0.07);
+    }
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+    body { font-family: 'DM Sans', sans-serif; background: var(--navy); color: var(--text); display: flex; height: 100vh; overflow: hidden; }
+
+    /* SIDEBAR (same as timetable) */
+    .sidebar { width: 220px; background: var(--sidebar); border-right: 1px solid var(--border); display: flex; flex-direction: column; padding: 24px 0; flex-shrink: 0; }
+    .brand { font-family: 'Sora', sans-serif; font-weight: 700; font-size: 1.2rem; color: var(--accent); padding: 0 22px; margin-bottom: 32px; display: flex; align-items: center; gap: 8px; }
+    .nav-section-label { font-size: 0.68rem; font-weight: 600; letter-spacing: 0.1em; color: var(--muted); text-transform: uppercase; padding: 0 22px; margin: 18px 0 8px; }
+    .nav-item { display: flex; align-items: center; gap: 10px; padding: 10px 22px; font-size: 0.88rem; font-weight: 500; color: var(--muted); cursor: pointer; transition: all 0.2s; text-decoration: none; }
+    .nav-item:hover, .nav-item.active { color: var(--text); background: rgba(79,142,247,0.1); }
+    .nav-item.active { color: var(--accent); border-right: 2px solid var(--accent); }
+    .nav-item i { width: 18px; text-align: center; font-size: 0.9rem; }
+    .sidebar-bottom { margin-top: auto; padding: 16px 22px; border-top: 1px solid var(--border); }
+    .avatar { width: 32px; height: 32px; border-radius: 50%; background: linear-gradient(135deg, var(--accent), var(--accent2)); display: flex; align-items: center; justify-content: center; font-size: 0.75rem; font-weight: 700; color: white; flex-shrink: 0; }
+
+    /* MAIN */
+    .main { flex: 1; display: flex; flex-direction: column; overflow: hidden; }
+    .topbar { padding: 16px 28px; border-bottom: 1px solid var(--border); display: flex; align-items: center; justify-content: space-between; background: var(--card); }
+    .breadcrumb-nav { display: flex; align-items: center; gap: 8px; font-size: 0.85rem; color: var(--muted); }
+    .breadcrumb-nav a { color: var(--muted); text-decoration: none; } .breadcrumb-nav a:hover { color: var(--accent); }
+    .breadcrumb-nav .sep { font-size: 0.7rem; }
+
+    .content { flex: 1; overflow-y: auto; padding: 28px; display: flex; gap: 24px; }
+
+    /* LEFT COLUMN */
+    .left-col { flex: 1; display: flex; flex-direction: column; gap: 20px; min-width: 0; }
+
+    .exam-hero {
+      background: linear-gradient(135deg, rgba(255,85,85,0.15) 0%, rgba(255,107,53,0.1) 100%);
+      border: 1px solid rgba(255,85,85,0.25);
+      border-radius: 14px;
+      padding: 24px;
+    }
+    .exam-badge {
+      display: inline-flex; align-items: center; gap: 6px;
+      background: rgba(255,85,85,0.2); color: var(--red);
+      font-size: 0.75rem; font-weight: 700; text-transform: uppercase; letter-spacing: 0.08em;
+      padding: 4px 12px; border-radius: 20px; margin-bottom: 14px;
+    }
+    .exam-title { font-family: 'Sora', sans-serif; font-weight: 700; font-size: 1.6rem; margin-bottom: 6px; }
+    .exam-meta { display: flex; gap: 20px; flex-wrap: wrap; margin-top: 16px; }
+    .meta-item { display: flex; align-items: center; gap: 8px; font-size: 0.85rem; color: var(--muted); }
+    .meta-item i { color: var(--accent); width: 14px; }
+
+    .countdown-strip {
+      display: flex; gap: 12px; margin-top: 20px;
+    }
+    .count-box {
+      flex: 1; background: rgba(255,255,255,0.05); border: 1px solid var(--border);
+      border-radius: 10px; padding: 12px; text-align: center;
+    }
+    .count-num { font-family: 'Sora', sans-serif; font-weight: 700; font-size: 1.8rem; color: var(--red); }
+    .count-label { font-size: 0.7rem; color: var(--muted); text-transform: uppercase; letter-spacing: 0.06em; }
+
+    /* PROGRESS CARD */
+    .card-section { background: var(--card); border: 1px solid var(--border); border-radius: 14px; padding: 20px; }
+    .section-title { font-family: 'Sora', sans-serif; font-weight: 600; font-size: 0.95rem; margin-bottom: 16px; display: flex; align-items: center; gap: 8px; }
+    .section-title i { color: var(--accent); }
+
+    .progress-label { display: flex; justify-content: space-between; font-size: 0.82rem; color: var(--muted); margin-bottom: 6px; }
+    .prog-bar { height: 8px; background: rgba(255,255,255,0.07); border-radius: 4px; overflow: hidden; margin-bottom: 14px; }
+    .prog-fill { height: 100%; border-radius: 4px; }
+
+    /* CHECKLIST */
+    .checklist-item {
+      display: flex; align-items: center; gap: 12px;
+      padding: 10px 12px; border-radius: 9px; margin-bottom: 6px;
+      cursor: pointer; transition: background 0.15s;
+      border: 1px solid transparent;
+    }
+    .checklist-item:hover { background: rgba(255,255,255,0.04); }
+    .checklist-item.done { opacity: 0.55; }
+    .check-box {
+      width: 20px; height: 20px; border-radius: 5px; border: 2px solid var(--border);
+      display: flex; align-items: center; justify-content: center; font-size: 0.7rem;
+      flex-shrink: 0; transition: all 0.2s;
+    }
+    .checklist-item.done .check-box { background: var(--green); border-color: var(--green); color: white; }
+    .check-label { font-size: 0.88rem; }
+    .checklist-item.done .check-label { text-decoration: line-through; color: var(--muted); }
+    .check-tag { margin-left: auto; font-size: 0.7rem; padding: 2px 8px; border-radius: 10px; font-weight: 600; }
+
+    .add-topic-btn {
+      display: flex; align-items: center; gap: 8px;
+      background: transparent; border: 1px dashed var(--border);
+      color: var(--muted); font-size: 0.83rem; font-family: 'DM Sans', sans-serif;
+      padding: 9px 14px; border-radius: 9px; cursor: pointer; width: 100%;
+      margin-top: 4px; transition: all 0.2s;
+    }
+    .add-topic-btn:hover { border-color: var(--accent); color: var(--accent); }
+
+    /* NOTES */
+    .notes-area {
+      width: 100%; background: rgba(255,255,255,0.04); border: 1px solid var(--border);
+      border-radius: 10px; color: var(--text); font-family: 'DM Sans', sans-serif;
+      font-size: 0.88rem; padding: 14px; resize: none; outline: none; line-height: 1.6;
+      min-height: 130px; transition: border-color 0.2s;
+    }
+    .notes-area:focus { border-color: var(--accent); }
+
+    /* RIGHT COLUMN */
+    .right-col { width: 300px; flex-shrink: 0; display: flex; flex-direction: column; gap: 20px; }
+
+    .ai-card {
+      background: linear-gradient(135deg, rgba(79,142,247,0.1), rgba(124,92,252,0.08));
+      border: 1px solid rgba(79,142,247,0.25);
+      border-radius: 14px; padding: 20px;
+    }
+    .ai-card-title { font-family: 'Sora', sans-serif; font-weight: 600; font-size: 0.9rem; margin-bottom: 10px; display: flex; align-items: center; gap: 7px; color: var(--accent); }
+    .ai-suggestion {
+      background: rgba(255,255,255,0.05); border-radius: 9px; padding: 12px 14px;
+      font-size: 0.82rem; color: var(--text); line-height: 1.6; margin-bottom: 12px;
+      border-left: 3px solid var(--accent);
+    }
+    .btn-ai {
+      background: linear-gradient(135deg, var(--accent), var(--accent2));
+      border: none; color: white; font-family: 'DM Sans', sans-serif;
+      font-size: 0.82rem; font-weight: 600; padding: 9px 14px;
+      border-radius: 8px; cursor: pointer; width: 100%;
+      display: flex; align-items: center; justify-content: center; gap: 6px;
+    }
+    .btn-ai:hover { opacity: 0.88; }
+
+    /* Resource links */
+    .resource-item {
+      display: flex; align-items: center; gap: 10px;
+      padding: 10px; background: rgba(255,255,255,0.03);
+      border: 1px solid var(--border); border-radius: 9px; margin-bottom: 8px;
+      font-size: 0.82rem; cursor: pointer; text-decoration: none; color: var(--text);
+      transition: background 0.15s;
+    }
+    .resource-item:hover { background: rgba(255,255,255,0.06); color: var(--text); }
+    .resource-icon { width: 30px; height: 30px; border-radius: 7px; display: flex; align-items: center; justify-content: center; font-size: 0.85rem; flex-shrink: 0; }
+
+    /* scrollbar */
+    .content::-webkit-scrollbar { width: 5px; }
+    .content::-webkit-scrollbar-thumb { background: var(--border); border-radius: 3px; }
+  </style>
+</head>
+<body>
+
+<!-- SIDEBAR -->
+<nav class="sidebar">
+  <div class="brand"><i class="fas fa-calendar-alt"></i> StudySync</div>
+  <span class="nav-section-label">Main</span>
+  <a href="timetable.html" class="nav-item"><i class="fas fa-calendar-week"></i> Timetable</a>
+  <a href="ai_planner.html" class="nav-item"><i class="fas fa-robot"></i> AI Planner</a>
+  <a href="group.html" class="nav-item"><i class="fas fa-users"></i> My Group</a>
+  <span class="nav-section-label">Personal</span>
+  <a href="#" class="nav-item"><i class="fas fa-book-open"></i> Courses</a>
+  <a href="exam_detail.html" class="nav-item active"><i class="fas fa-file-alt"></i> Exams &amp; Tasks</a>
+  <a href="#" class="nav-item"><i class="fas fa-bell"></i> Reminders</a>
+  <span class="nav-section-label">Settings</span>
+  <a href="#" class="nav-item"><i class="fas fa-cog"></i> Preferences</a>
+  <div class="sidebar-bottom">
+    <div style="display:flex;align-items:center;gap:10px">
+      <div class="avatar">JS</div>
+      <div>
+        <div style="font-size:0.82rem;font-weight:600;">Jane Smith</div>
+        <div style="font-size:0.72rem;color:var(--muted);">23456789</div>
+      </div>
+    </div>
+  </div>
+</nav>
+
+<!-- MAIN -->
+<div class="main">
+  <div class="topbar">
+    <div class="breadcrumb-nav">
+      <a href="timetable.html"><i class="fas fa-calendar-week"></i> Timetable</a>
+      <span class="sep"><i class="fas fa-chevron-right"></i></span>
+      <a href="#">CITS3403</a>
+      <span class="sep"><i class="fas fa-chevron-right"></i></span>
+      <span style="color:var(--text)">Mid-semester Test</span>
+    </div>
+    <div style="display:flex;gap:10px">
+      <button style="background:rgba(255,255,255,0.05);border:1px solid var(--border);color:var(--muted);font-size:0.82rem;padding:7px 14px;border-radius:8px;cursor:pointer;">
+        <i class="fas fa-share-alt"></i> Share
+      </button>
+      <button style="background:rgba(255,85,85,0.15);border:1px solid rgba(255,85,85,0.3);color:var(--red);font-size:0.82rem;padding:7px 14px;border-radius:8px;cursor:pointer;">
+        <i class="fas fa-trash"></i>
+      </button>
+    </div>
+  </div>
+
+  <div class="content">
+
+    <!-- LEFT -->
+    <div class="left-col">
+
+      <!-- EXAM HERO -->
+      <div class="exam-hero">
+        <div class="exam-badge"><i class="fas fa-exclamation-triangle"></i> Exam</div>
+        <div class="exam-title">CITS3403 — Mid-semester Test</div>
+        <div class="exam-meta">
+          <div class="meta-item"><i class="fas fa-calendar"></i> Tuesday, 15 April 2026</div>
+          <div class="meta-item"><i class="fas fa-clock"></i> 10:00 AM – 11:00 AM</div>
+          <div class="meta-item"><i class="fas fa-map-marker-alt"></i> Room 106, CS Building</div>
+          <div class="meta-item"><i class="fas fa-weight-hanging"></i> 20% of final grade</div>
+        </div>
+        <div class="countdown-strip">
+          <div class="count-box"><div class="count-num">0</div><div class="count-label">Days</div></div>
+          <div class="count-box"><div class="count-num">2</div><div class="count-label">Hours</div></div>
+          <div class="count-box"><div class="count-num">35</div><div class="count-label">Minutes</div></div>
+        </div>
+      </div>
+
+      <!-- PROGRESS -->
+      <div class="card-section">
+        <div class="section-title"><i class="fas fa-chart-line"></i> Revision Progress</div>
+        <div class="progress-label"><span>HTML &amp; CSS Fundamentals</span><span style="color:var(--green)">100%</span></div>
+        <div class="prog-bar"><div class="prog-fill" style="width:100%;background:var(--green)"></div></div>
+        <div class="progress-label"><span>JavaScript &amp; DOM</span><span style="color:var(--yellow)">65%</span></div>
+        <div class="prog-bar"><div class="prog-fill" style="width:65%;background:var(--yellow)"></div></div>
+        <div class="progress-label"><span>Flask Basics</span><span style="color:var(--orange)">30%</span></div>
+        <div class="prog-bar"><div class="prog-fill" style="width:30%;background:var(--orange)"></div></div>
+        <div class="progress-label"><span>SQLAlchemy &amp; Models</span><span style="color:var(--red)">10%</span></div>
+        <div class="prog-bar" style="margin-bottom:0"><div class="prog-fill" style="width:10%;background:var(--red)"></div></div>
+      </div>
+
+      <!-- TOPICS CHECKLIST -->
+      <div class="card-section">
+        <div class="section-title"><i class="fas fa-tasks"></i> Topics to Revise</div>
+
+        <div class="checklist-item done" onclick="this.classList.toggle('done')">
+          <div class="check-box"><i class="fas fa-check"></i></div>
+          <span class="check-label">HTML semantic elements &amp; forms</span>
+          <span class="check-tag" style="background:rgba(38,208,124,0.15);color:var(--green)">Done</span>
+        </div>
+        <div class="checklist-item done" onclick="this.classList.toggle('done')">
+          <div class="check-box"><i class="fas fa-check"></i></div>
+          <span class="check-label">CSS flexbox &amp; grid layout</span>
+          <span class="check-tag" style="background:rgba(38,208,124,0.15);color:var(--green)">Done</span>
+        </div>
+        <div class="checklist-item done" onclick="this.classList.toggle('done')">
+          <div class="check-box"><i class="fas fa-check"></i></div>
+          <span class="check-label">Bootstrap 5 components</span>
+          <span class="check-tag" style="background:rgba(38,208,124,0.15);color:var(--green)">Done</span>
+        </div>
+        <div class="checklist-item" onclick="this.classList.toggle('done')">
+          <div class="check-box"></div>
+          <span class="check-label">JavaScript event listeners &amp; DOM manipulation</span>
+          <span class="check-tag" style="background:rgba(255,201,74,0.15);color:var(--yellow)">In Progress</span>
+        </div>
+        <div class="checklist-item" onclick="this.classList.toggle('done')">
+          <div class="check-box"></div>
+          <span class="check-label">AJAX &amp; fetch API</span>
+          <span class="check-tag" style="background:rgba(255,201,74,0.15);color:var(--yellow)">In Progress</span>
+        </div>
+        <div class="checklist-item" onclick="this.classList.toggle('done')">
+          <div class="check-box"></div>
+          <span class="check-label">Flask routes &amp; Jinja2 templates</span>
+          <span class="check-tag" style="background:rgba(255,85,85,0.15);color:var(--red)">Not Started</span>
+        </div>
+        <div class="checklist-item" onclick="this.classList.toggle('done')">
+          <div class="check-box"></div>
+          <span class="check-label">SQLAlchemy models &amp; relationships</span>
+          <span class="check-tag" style="background:rgba(255,85,85,0.15);color:var(--red)">Not Started</span>
+        </div>
+
+        <button class="add-topic-btn"><i class="fas fa-plus"></i> Add topic</button>
+      </div>
+
+      <!-- NOTES -->
+      <div class="card-section">
+        <div class="section-title"><i class="fas fa-sticky-note"></i> Personal Notes</div>
+        <textarea class="notes-area" placeholder="Add your revision notes here... e.g. 'Remember: use url_for() for Flask redirects, not hardcoded paths'">- Flask app factory pattern: create_app() function
+- SQLAlchemy session vs query interface
+- Remember CSRF tokens for all forms!</textarea>
+      </div>
+
+    </div>
+
+    <!-- RIGHT -->
+    <div class="right-col">
+
+      <!-- AI SUGGESTIONS -->
+      <div class="ai-card">
+        <div class="ai-card-title"><i class="fas fa-robot"></i> AI Study Suggestion</div>
+        <div class="ai-suggestion">
+          You have <strong>2 hours 35 minutes</strong> until your test. Based on your progress, focus on <strong>Flask routes</strong> and <strong>SQLAlchemy</strong> — these are the weakest areas. Skip re-reading HTML/CSS, you're solid there.
+        </div>
+        <button class="btn-ai" onclick="window.location.href='ai_planner.html'">
+          <i class="fas fa-comments"></i> Ask AI for more help
+        </button>
+      </div>
+
+      <!-- RELATED RESOURCES -->
+      <div class="card-section">
+        <div class="section-title"><i class="fas fa-link"></i> Resources</div>
+        <a href="#" class="resource-item">
+          <div class="resource-icon" style="background:rgba(255,107,53,0.15);color:var(--orange)"><i class="fas fa-file-pdf"></i></div>
+          <div>
+            <div style="font-weight:600;font-size:0.82rem;">Week 1-4 Lecture Slides</div>
+            <div style="font-size:0.72rem;color:var(--muted);">LMS — PDF, 4.2 MB</div>
+          </div>
+        </a>
+        <a href="#" class="resource-item">
+          <div class="resource-icon" style="background:rgba(79,142,247,0.15);color:var(--accent)"><i class="fab fa-youtube"></i></div>
+          <div>
+            <div style="font-weight:600;font-size:0.82rem;">Flask Tutorial (CS50)</div>
+            <div style="font-size:0.72rem;color:var(--muted);">YouTube — 45 min</div>
+          </div>
+        </a>
+        <a href="#" class="resource-item">
+          <div class="resource-icon" style="background:rgba(38,208,124,0.15);color:var(--green)"><i class="fas fa-globe"></i></div>
+          <div>
+            <div style="font-weight:600;font-size:0.82rem;">SQLAlchemy Docs</div>
+            <div style="font-size:0.72rem;color:var(--muted);">docs.sqlalchemy.org</div>
+          </div>
+        </a>
+        <button class="add-topic-btn" style="margin-top:4px"><i class="fas fa-plus"></i> Add resource</button>
+      </div>
+
+      <!-- SIMILAR EXAMS IN GROUP -->
+      <div class="card-section">
+        <div class="section-title"><i class="fas fa-users"></i> Group Members' Status</div>
+        <div style="display:flex;flex-direction:column;gap:10px;">
+          <div style="display:flex;align-items:center;gap:10px;">
+            <div style="width:28px;height:28px;border-radius:50%;background:linear-gradient(135deg,#ff6b35,#ff9a35);display:flex;align-items:center;justify-content:center;font-size:0.7rem;font-weight:700;color:white">TL</div>
+            <div style="flex:1">
+              <div style="font-size:0.82rem;font-weight:600;">Tom Liu</div>
+              <div class="prog-bar" style="margin:4px 0 0;height:5px"><div class="prog-fill" style="width:80%;background:var(--green)"></div></div>
+            </div>
+            <span style="font-size:0.75rem;color:var(--green)">80%</span>
+          </div>
+          <div style="display:flex;align-items:center;gap:10px;">
+            <div style="width:28px;height:28px;border-radius:50%;background:linear-gradient(135deg,#e040fb,#7c5cfc);display:flex;align-items:center;justify-content:center;font-size:0.7rem;font-weight:700;color:white">AK</div>
+            <div style="flex:1">
+              <div style="font-size:0.82rem;font-weight:600;">Amy Kim</div>
+              <div class="prog-bar" style="margin:4px 0 0;height:5px"><div class="prog-fill" style="width:45%;background:var(--yellow)"></div></div>
+            </div>
+            <span style="font-size:0.75rem;color:var(--yellow)">45%</span>
+          </div>
+          <div style="display:flex;align-items:center;gap:10px;">
+            <div style="width:28px;height:28px;border-radius:50%;background:linear-gradient(135deg,#26d07c,#4f8ef7);display:flex;align-items:center;justify-content:center;font-size:0.7rem;font-weight:700;color:white">RZ</div>
+            <div style="flex:1">
+              <div style="font-size:0.82rem;font-weight:600;">Ryan Zhang</div>
+              <div class="prog-bar" style="margin:4px 0 0;height:5px"><div class="prog-fill" style="width:60%;background:var(--accent)"></div></div>
+            </div>
+            <span style="font-size:0.75rem;color:var(--accent)">60%</span>
+          </div>
+        </div>
+      </div>
+
+    </div>
+  </div>
+</div>
+
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+</body>
+</html>

--- a/mock_pages/group.html
+++ b/mock_pages/group.html
@@ -1,0 +1,446 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8"/>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+  <title>StudySync — My Group</title>
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet"/>
+  <link href="https://fonts.googleapis.com/css2?family=Sora:wght@300;400;600;700&family=DM+Sans:ital,wght@0,300;0,400;0,500;1,300&display=swap" rel="stylesheet"/>
+  <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" rel="stylesheet"/>
+  <style>
+    :root {
+      --navy: #0d1b2a; --card: #111f30; --sidebar: #0f1e2e;
+      --accent: #4f8ef7; --accent2: #7c5cfc; --orange: #ff6b35;
+      --pink: #e040fb; --green: #26d07c; --yellow: #ffc94a; --red: #ff5555;
+      --text: #e8edf5; --muted: #6b839e; --border: rgba(255,255,255,0.07);
+    }
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+    body { font-family: 'DM Sans', sans-serif; background: var(--navy); color: var(--text); display: flex; height: 100vh; overflow: hidden; }
+
+    .sidebar { width: 220px; background: var(--sidebar); border-right: 1px solid var(--border); display: flex; flex-direction: column; padding: 24px 0; flex-shrink: 0; }
+    .brand { font-family: 'Sora', sans-serif; font-weight: 700; font-size: 1.2rem; color: var(--accent); padding: 0 22px; margin-bottom: 32px; display: flex; align-items: center; gap: 8px; }
+    .nav-section-label { font-size: 0.68rem; font-weight: 600; letter-spacing: 0.1em; color: var(--muted); text-transform: uppercase; padding: 0 22px; margin: 18px 0 8px; }
+    .nav-item { display: flex; align-items: center; gap: 10px; padding: 10px 22px; font-size: 0.88rem; font-weight: 500; color: var(--muted); cursor: pointer; transition: all 0.2s; text-decoration: none; }
+    .nav-item:hover, .nav-item.active { color: var(--text); background: rgba(79,142,247,0.1); }
+    .nav-item.active { color: var(--accent); border-right: 2px solid var(--accent); }
+    .nav-item i { width: 18px; text-align: center; font-size: 0.9rem; }
+    .sidebar-bottom { margin-top: auto; padding: 16px 22px; border-top: 1px solid var(--border); }
+    .avatar { width: 32px; height: 32px; border-radius: 50%; background: linear-gradient(135deg, var(--accent), var(--accent2)); display: flex; align-items: center; justify-content: center; font-size: 0.75rem; font-weight: 700; color: white; flex-shrink: 0; }
+
+    .main { flex: 1; display: flex; flex-direction: column; overflow: hidden; }
+    .topbar { padding: 16px 28px; border-bottom: 1px solid var(--border); display: flex; align-items: center; justify-content: space-between; background: var(--card); }
+    .page-title { font-family: 'Sora', sans-serif; font-weight: 700; font-size: 1.4rem; }
+    .btn-invite { background: var(--accent); border: none; color: white; font-family: 'DM Sans', sans-serif; font-size: 0.85rem; font-weight: 600; padding: 8px 16px; border-radius: 8px; cursor: pointer; display: flex; align-items: center; gap: 6px; }
+
+    .content { flex: 1; overflow-y: auto; padding: 24px 28px; display: flex; gap: 22px; }
+    .content::-webkit-scrollbar { width: 5px; }
+    .content::-webkit-scrollbar-thumb { background: var(--border); border-radius: 3px; }
+
+    /* MEMBER CARDS */
+    .left-col { width: 300px; flex-shrink: 0; display: flex; flex-direction: column; gap: 16px; }
+
+    .group-info-card {
+      background: linear-gradient(135deg, rgba(79,142,247,0.12), rgba(124,92,252,0.08));
+      border: 1px solid rgba(79,142,247,0.2);
+      border-radius: 14px; padding: 20px;
+    }
+    .group-name { font-family: 'Sora', sans-serif; font-weight: 700; font-size: 1.1rem; margin-bottom: 4px; }
+    .group-code { font-size: 0.8rem; color: var(--muted); margin-bottom: 16px; }
+    .member-stack { display: flex; margin-bottom: 12px; }
+    .member-stack .sm-avatar {
+      width: 32px; height: 32px; border-radius: 50%; border: 2px solid var(--navy);
+      display: flex; align-items: center; justify-content: center;
+      font-size: 0.7rem; font-weight: 700; color: white; margin-left: -8px;
+    }
+    .member-stack .sm-avatar:first-child { margin-left: 0; }
+    .group-stat { font-size: 0.82rem; color: var(--muted); }
+    .group-stat strong { color: var(--text); }
+
+    .section-header { font-family: 'Sora', sans-serif; font-weight: 600; font-size: 0.9rem; color: var(--muted); text-transform: uppercase; letter-spacing: 0.06em; margin-bottom: 12px; display: flex; align-items: center; gap: 6px; }
+
+    .member-card {
+      background: var(--card); border: 1px solid var(--border);
+      border-radius: 12px; padding: 16px; cursor: pointer;
+      transition: border-color 0.2s, background 0.2s;
+    }
+    .member-card:hover { border-color: rgba(79,142,247,0.3); background: rgba(79,142,247,0.05); }
+    .member-card.selected { border-color: var(--accent); background: rgba(79,142,247,0.08); }
+    .member-top { display: flex; align-items: center; gap: 12px; margin-bottom: 12px; }
+    .mem-avatar { width: 40px; height: 40px; border-radius: 10px; display: flex; align-items: center; justify-content: center; font-size: 0.85rem; font-weight: 700; color: white; flex-shrink: 0; }
+    .mem-name { font-weight: 600; font-size: 0.92rem; }
+    .mem-id { font-size: 0.75rem; color: var(--muted); }
+    .online-badge { margin-left: auto; display: flex; align-items: center; gap: 5px; font-size: 0.72rem; color: var(--green); }
+    .online-dot { width: 7px; height: 7px; background: var(--green); border-radius: 50%; }
+    .offline-badge { margin-left: auto; font-size: 0.72rem; color: var(--muted); }
+
+    .mem-stats { display: flex; gap: 12px; }
+    .mem-stat-item { flex: 1; background: rgba(255,255,255,0.04); border-radius: 8px; padding: 8px; text-align: center; }
+    .mem-stat-num { font-family: 'Sora', sans-serif; font-weight: 700; font-size: 1rem; }
+    .mem-stat-label { font-size: 0.65rem; color: var(--muted); text-transform: uppercase; letter-spacing: 0.05em; }
+
+    /* RIGHT: Shared timetable */
+    .right-col { flex: 1; min-width: 0; display: flex; flex-direction: column; gap: 20px; }
+
+    .free-slot-card {
+      background: linear-gradient(135deg, rgba(38,208,124,0.1), rgba(79,142,247,0.08));
+      border: 1px solid rgba(38,208,124,0.2);
+      border-radius: 14px; padding: 18px;
+    }
+    .free-slot-title { font-family: 'Sora', sans-serif; font-weight: 700; font-size: 0.95rem; margin-bottom: 12px; display: flex; align-items: center; gap: 8px; color: var(--green); }
+    .slot-pills { display: flex; gap: 8px; flex-wrap: wrap; }
+    .slot-pill {
+      display: flex; align-items: center; gap: 7px;
+      background: rgba(38,208,124,0.1); border: 1px solid rgba(38,208,124,0.25);
+      border-radius: 8px; padding: 8px 14px; font-size: 0.82rem;
+    }
+    .slot-pill i { color: var(--green); }
+    .btn-book { margin-left: auto; background: rgba(38,208,124,0.15); border: 1px solid rgba(38,208,124,0.3); color: var(--green); font-size: 0.72rem; font-family: 'DM Sans', sans-serif; padding: 3px 10px; border-radius: 6px; cursor: pointer; font-weight: 600; }
+    .btn-book:hover { background: rgba(38,208,124,0.25); }
+
+    /* SHARED TIMETABLE */
+    .shared-grid {
+      background: var(--card); border: 1px solid var(--border);
+      border-radius: 14px; overflow: hidden;
+    }
+    .grid-header {
+      display: grid; grid-template-columns: 70px repeat(5, 1fr);
+      border-bottom: 1px solid var(--border);
+      background: rgba(255,255,255,0.02);
+    }
+    .grid-day { padding: 12px 8px; text-align: center; font-size: 0.78rem; font-weight: 600; color: var(--muted); text-transform: uppercase; letter-spacing: 0.05em; }
+    .grid-day.today { color: var(--accent); }
+
+    .grid-body { overflow-y: auto; max-height: 420px; }
+    .grid-body::-webkit-scrollbar { width: 4px; }
+    .grid-body::-webkit-scrollbar-thumb { background: var(--border); border-radius: 2px; }
+
+    .grid-row {
+      display: grid; grid-template-columns: 70px repeat(5, 1fr);
+      border-bottom: 1px solid var(--border);
+    }
+    .grid-row:last-child { border-bottom: none; }
+    .time-cell { padding: 12px 8px; font-size: 0.72rem; color: var(--muted); text-align: center; font-weight: 500; border-right: 1px solid var(--border); }
+    .day-cell { padding: 6px; min-height: 64px; border-right: 1px solid var(--border); position: relative; }
+    .day-cell:last-child { border-right: none; }
+
+    /* free slot highlight */
+    .day-cell.free-all {
+      background: rgba(38,208,124,0.06);
+    }
+
+    .mini-event {
+      border-radius: 5px; padding: 4px 7px; font-size: 0.7rem;
+      font-weight: 600; margin-bottom: 3px; display: flex; align-items: center; gap: 4px;
+    }
+    .mini-dot { width: 6px; height: 6px; border-radius: 50%; flex-shrink: 0; }
+
+    /* tasks panel */
+    .task-row {
+      display: flex; align-items: center; gap: 12px;
+      padding: 10px 14px; border-radius: 9px; margin-bottom: 6px;
+      background: rgba(255,255,255,0.03); border: 1px solid var(--border);
+    }
+    .task-assignee { width: 26px; height: 26px; border-radius: 50%; display: flex; align-items: center; justify-content: center; font-size: 0.65rem; font-weight: 700; color: white; flex-shrink: 0; }
+    .task-name { font-size: 0.85rem; font-weight: 500; }
+    .task-due { margin-left: auto; font-size: 0.72rem; color: var(--muted); }
+    .task-status { font-size: 0.7rem; font-weight: 700; padding: 2px 8px; border-radius: 10px; }
+  </style>
+</head>
+<body>
+
+<!-- SIDEBAR -->
+<nav class="sidebar">
+  <div class="brand"><i class="fas fa-calendar-alt"></i> StudySync</div>
+  <span class="nav-section-label">Main</span>
+  <a href="timetable.html" class="nav-item"><i class="fas fa-calendar-week"></i> Timetable</a>
+  <a href="ai_planner.html" class="nav-item"><i class="fas fa-robot"></i> AI Planner</a>
+  <a href="group.html" class="nav-item active"><i class="fas fa-users"></i> My Group</a>
+  <span class="nav-section-label">Personal</span>
+  <a href="#" class="nav-item"><i class="fas fa-book-open"></i> Courses</a>
+  <a href="exam_detail.html" class="nav-item"><i class="fas fa-file-alt"></i> Exams &amp; Tasks</a>
+  <a href="#" class="nav-item"><i class="fas fa-bell"></i> Reminders</a>
+  <span class="nav-section-label">Settings</span>
+  <a href="#" class="nav-item"><i class="fas fa-cog"></i> Preferences</a>
+  <div class="sidebar-bottom">
+    <div style="display:flex;align-items:center;gap:10px">
+      <div class="avatar">JS</div>
+      <div>
+        <div style="font-size:0.82rem;font-weight:600;">Jane Smith</div>
+        <div style="font-size:0.72rem;color:var(--muted);">23456789</div>
+      </div>
+    </div>
+  </div>
+</nav>
+
+<!-- MAIN -->
+<div class="main">
+  <div class="topbar">
+    <div class="page-title">My Group</div>
+    <button class="btn-invite"><i class="fas fa-user-plus"></i> Invite Member</button>
+  </div>
+
+  <div class="content">
+
+    <!-- LEFT: members -->
+    <div class="left-col">
+
+      <div class="group-info-card">
+        <div class="group-name">CITS3403 Group 7</div>
+        <div class="group-code">Group Code: <strong style="color:var(--accent)">GRP-3403-07</strong></div>
+        <div class="member-stack">
+          <div class="sm-avatar" style="background:linear-gradient(135deg,var(--accent),var(--accent2))">JS</div>
+          <div class="sm-avatar" style="background:linear-gradient(135deg,#ff6b35,#ffc94a)">TL</div>
+          <div class="sm-avatar" style="background:linear-gradient(135deg,#e040fb,#7c5cfc)">AK</div>
+          <div class="sm-avatar" style="background:linear-gradient(135deg,#26d07c,#4f8ef7)">RZ</div>
+        </div>
+        <div class="group-stat">4 members · <strong>Checkpoint 2</strong> in 3 weeks</div>
+      </div>
+
+      <div class="section-header"><i class="fas fa-users"></i> Members</div>
+
+      <!-- Member 1: Jane (you) -->
+      <div class="member-card selected">
+        <div class="member-top">
+          <div class="mem-avatar" style="background:linear-gradient(135deg,var(--accent),var(--accent2))">JS</div>
+          <div>
+            <div class="mem-name">Jane Smith <span style="font-size:0.7rem;color:var(--accent);font-weight:600">(You)</span></div>
+            <div class="mem-id">23456789</div>
+          </div>
+          <div class="online-badge"><span class="online-dot"></span> Online</div>
+        </div>
+        <div class="mem-stats">
+          <div class="mem-stat-item"><div class="mem-stat-num" style="color:var(--accent)">12</div><div class="mem-stat-label">Commits</div></div>
+          <div class="mem-stat-item"><div class="mem-stat-num" style="color:var(--green)">5</div><div class="mem-stat-label">Issues</div></div>
+          <div class="mem-stat-item"><div class="mem-stat-num" style="color:var(--yellow)">3</div><div class="mem-stat-label">PRs</div></div>
+        </div>
+      </div>
+
+      <!-- Member 2 -->
+      <div class="member-card">
+        <div class="member-top">
+          <div class="mem-avatar" style="background:linear-gradient(135deg,#ff6b35,#ffc94a)">TL</div>
+          <div>
+            <div class="mem-name">Tom Liu</div>
+            <div class="mem-id">23112233</div>
+          </div>
+          <div class="online-badge"><span class="online-dot"></span> Online</div>
+        </div>
+        <div class="mem-stats">
+          <div class="mem-stat-item"><div class="mem-stat-num" style="color:var(--accent)">18</div><div class="mem-stat-label">Commits</div></div>
+          <div class="mem-stat-item"><div class="mem-stat-num" style="color:var(--green)">7</div><div class="mem-stat-label">Issues</div></div>
+          <div class="mem-stat-item"><div class="mem-stat-num" style="color:var(--yellow)">4</div><div class="mem-stat-label">PRs</div></div>
+        </div>
+      </div>
+
+      <!-- Member 3 -->
+      <div class="member-card">
+        <div class="member-top">
+          <div class="mem-avatar" style="background:linear-gradient(135deg,#e040fb,#7c5cfc)">AK</div>
+          <div>
+            <div class="mem-name">Amy Kim</div>
+            <div class="mem-id">23334455</div>
+          </div>
+          <div class="offline-badge">Last seen 1h ago</div>
+        </div>
+        <div class="mem-stats">
+          <div class="mem-stat-item"><div class="mem-stat-num" style="color:var(--accent)">9</div><div class="mem-stat-label">Commits</div></div>
+          <div class="mem-stat-item"><div class="mem-stat-num" style="color:var(--green)">4</div><div class="mem-stat-label">Issues</div></div>
+          <div class="mem-stat-item"><div class="mem-stat-num" style="color:var(--yellow)">2</div><div class="mem-stat-label">PRs</div></div>
+        </div>
+      </div>
+
+      <!-- Member 4 -->
+      <div class="member-card">
+        <div class="member-top">
+          <div class="mem-avatar" style="background:linear-gradient(135deg,#26d07c,#4f8ef7)">RZ</div>
+          <div>
+            <div class="mem-name">Ryan Zhang</div>
+            <div class="mem-id">23556677</div>
+          </div>
+          <div class="online-badge"><span class="online-dot"></span> Online</div>
+        </div>
+        <div class="mem-stats">
+          <div class="mem-stat-item"><div class="mem-stat-num" style="color:var(--accent)">15</div><div class="mem-stat-label">Commits</div></div>
+          <div class="mem-stat-item"><div class="mem-stat-num" style="color:var(--green)">6</div><div class="mem-stat-label">Issues</div></div>
+          <div class="mem-stat-item"><div class="mem-stat-num" style="color:var(--yellow)">5</div><div class="mem-stat-label">PRs</div></div>
+        </div>
+      </div>
+
+    </div>
+
+    <!-- RIGHT: shared view -->
+    <div class="right-col">
+
+      <!-- Free slots -->
+      <div class="free-slot-card">
+        <div class="free-slot-title"><i class="fas fa-magic"></i> Common Free Slots This Week</div>
+        <div class="slot-pills">
+          <div class="slot-pill"><i class="fas fa-clock"></i> Mon 12–2 PM (all 4 free) <button class="btn-book">Book</button></div>
+          <div class="slot-pill"><i class="fas fa-clock"></i> Wed 11 AM–1 PM (all 4 free) <button class="btn-book">Book</button></div>
+          <div class="slot-pill"><i class="fas fa-clock"></i> Fri 2–4 PM (3 of 4 free) <button class="btn-book">Book</button></div>
+        </div>
+      </div>
+
+      <!-- Group timetable grid -->
+      <div class="shared-grid">
+        <div style="display:flex;align-items:center;justify-content:space-between;padding:14px 16px;border-bottom:1px solid var(--border);">
+          <div style="font-family:'Sora',sans-serif;font-weight:700;font-size:0.95rem;">Group Timetable — Week of 14 Apr</div>
+          <div style="display:flex;gap:14px;font-size:0.75rem;">
+            <span style="display:flex;align-items:center;gap:5px;color:var(--muted)"><span style="width:10px;height:10px;background:rgba(79,142,247,0.4);border-radius:2px;display:inline-block"></span> Lecture</span>
+            <span style="display:flex;align-items:center;gap:5px;color:var(--muted)"><span style="width:10px;height:10px;background:rgba(255,107,53,0.4);border-radius:2px;display:inline-block"></span> Lab</span>
+            <span style="display:flex;align-items:center;gap:5px;color:var(--green)"><span style="width:10px;height:10px;background:rgba(38,208,124,0.3);border-radius:2px;display:inline-block"></span> All free</span>
+          </div>
+        </div>
+
+        <div class="grid-header">
+          <div class="grid-day"></div>
+          <div class="grid-day">Mon</div>
+          <div class="grid-day today">Tue</div>
+          <div class="grid-day">Wed</div>
+          <div class="grid-day">Thu</div>
+          <div class="grid-day">Fri</div>
+        </div>
+
+        <div class="grid-body">
+          <!-- 9 AM -->
+          <div class="grid-row">
+            <div class="time-cell">9 AM</div>
+            <div class="day-cell">
+              <div class="mini-event" style="background:rgba(255,107,53,0.2);color:var(--orange)"><div class="mini-dot" style="background:var(--orange)"></div>JS · Lab</div>
+            </div>
+            <div class="day-cell">
+              <div class="mini-event" style="background:rgba(79,142,247,0.2);color:var(--accent)"><div class="mini-dot" style="background:var(--accent)"></div>TL · Lec</div>
+              <div class="mini-event" style="background:rgba(224,64,251,0.2);color:var(--pink)"><div class="mini-dot" style="background:var(--pink)"></div>AK · Lec</div>
+            </div>
+            <div class="day-cell">
+              <div class="mini-event" style="background:rgba(79,142,247,0.2);color:var(--accent)"><div class="mini-dot" style="background:var(--accent)"></div>JS · Lec</div>
+            </div>
+            <div class="day-cell"></div>
+            <div class="day-cell"></div>
+          </div>
+          <!-- 10 AM -->
+          <div class="grid-row">
+            <div class="time-cell">10 AM</div>
+            <div class="day-cell">
+              <div class="mini-event" style="background:rgba(255,107,53,0.2);color:var(--orange)"><div class="mini-dot" style="background:var(--orange)"></div>JS · Lab</div>
+            </div>
+            <div class="day-cell">
+              <div class="mini-event" style="background:rgba(255,85,85,0.2);color:var(--red)"><div class="mini-dot" style="background:var(--red)"></div>ALL · Exam</div>
+            </div>
+            <div class="day-cell">
+              <div class="mini-event" style="background:rgba(255,107,53,0.2);color:var(--orange)"><div class="mini-dot" style="background:var(--orange)"></div>RZ · Lab</div>
+            </div>
+            <div class="day-cell">
+              <div class="mini-event" style="background:rgba(79,142,247,0.2);color:var(--accent)"><div class="mini-dot" style="background:var(--accent)"></div>AK · Lec</div>
+            </div>
+            <div class="day-cell"></div>
+          </div>
+          <!-- 11 AM -->
+          <div class="grid-row">
+            <div class="time-cell">11 AM</div>
+            <div class="day-cell"></div>
+            <div class="day-cell"></div>
+            <div class="day-cell">
+              <div class="mini-event" style="background:rgba(224,64,251,0.2);color:var(--pink)"><div class="mini-dot" style="background:var(--pink)"></div>TL · Tut</div>
+            </div>
+            <div class="day-cell"></div>
+            <div class="day-cell"></div>
+          </div>
+          <!-- 12 PM -->
+          <div class="grid-row">
+            <div class="time-cell">12 PM</div>
+            <div class="day-cell free-all"></div>
+            <div class="day-cell free-all"></div>
+            <div class="day-cell free-all"></div>
+            <div class="day-cell free-all"></div>
+            <div class="day-cell free-all"></div>
+          </div>
+          <!-- 1 PM -->
+          <div class="grid-row">
+            <div class="time-cell">1 PM</div>
+            <div class="day-cell free-all"></div>
+            <div class="day-cell">
+              <div class="mini-event" style="background:rgba(79,142,247,0.2);color:var(--accent)"><div class="mini-dot" style="background:var(--accent)"></div>RZ · Lec</div>
+            </div>
+            <div class="day-cell free-all"></div>
+            <div class="day-cell">
+              <div class="mini-event" style="background:rgba(255,107,53,0.2);color:var(--orange)"><div class="mini-dot" style="background:var(--orange)"></div>AK · Lab</div>
+            </div>
+            <div class="day-cell free-all"></div>
+          </div>
+          <!-- 2 PM -->
+          <div class="grid-row">
+            <div class="time-cell">2 PM</div>
+            <div class="day-cell"></div>
+            <div class="day-cell"></div>
+            <div class="day-cell"></div>
+            <div class="day-cell">
+              <div class="mini-event" style="background:rgba(224,64,251,0.2);color:var(--pink)"><div class="mini-dot" style="background:var(--pink)"></div>JS · Tut</div>
+            </div>
+            <div class="day-cell"></div>
+          </div>
+          <!-- 3 PM -->
+          <div class="grid-row">
+            <div class="time-cell">3 PM</div>
+            <div class="day-cell"></div>
+            <div class="day-cell"></div>
+            <div class="day-cell">
+              <div class="mini-event" style="background:rgba(255,107,53,0.2);color:var(--orange)"><div class="mini-dot" style="background:var(--orange)"></div>TL · Lab</div>
+            </div>
+            <div class="day-cell"></div>
+            <div class="day-cell"></div>
+          </div>
+        </div>
+      </div>
+
+      <!-- GROUP TASKS -->
+      <div style="background:var(--card);border:1px solid var(--border);border-radius:14px;padding:18px;">
+        <div style="font-family:'Sora',sans-serif;font-weight:700;font-size:0.95rem;margin-bottom:14px;display:flex;align-items:center;justify-content:space-between;">
+          <span><i class="fas fa-tasks" style="color:var(--accent);margin-right:8px"></i>Project Tasks</span>
+          <button style="background:rgba(79,142,247,0.1);border:1px solid rgba(79,142,247,0.2);color:var(--accent);font-size:0.75rem;padding:4px 10px;border-radius:7px;cursor:pointer;font-family:'DM Sans',sans-serif;font-weight:600"><i class="fas fa-plus"></i> Add</button>
+        </div>
+        <div class="task-row">
+          <div class="task-assignee" style="background:linear-gradient(135deg,var(--accent),var(--accent2))">JS</div>
+          <div>
+            <div class="task-name">Login / Register pages (HTML)</div>
+            <div style="font-size:0.72rem;color:var(--muted)">Assigned to Jane</div>
+          </div>
+          <div class="task-due">Due Apr 18</div>
+          <div class="task-status" style="background:rgba(38,208,124,0.15);color:var(--green)">Done</div>
+        </div>
+        <div class="task-row">
+          <div class="task-assignee" style="background:linear-gradient(135deg,#ff6b35,#ffc94a)">TL</div>
+          <div>
+            <div class="task-name">Timetable grid component</div>
+            <div style="font-size:0.72rem;color:var(--muted)">Assigned to Tom</div>
+          </div>
+          <div class="task-due">Due Apr 18</div>
+          <div class="task-status" style="background:rgba(255,201,74,0.15);color:var(--yellow)">In Progress</div>
+        </div>
+        <div class="task-row">
+          <div class="task-assignee" style="background:linear-gradient(135deg,#e040fb,#7c5cfc)">AK</div>
+          <div>
+            <div class="task-name">User stories &amp; page list document</div>
+            <div style="font-size:0.72rem;color:var(--muted)">Assigned to Amy</div>
+          </div>
+          <div class="task-due">Due Apr 16</div>
+          <div class="task-status" style="background:rgba(38,208,124,0.15);color:var(--green)">Done</div>
+        </div>
+        <div class="task-row">
+          <div class="task-assignee" style="background:linear-gradient(135deg,#26d07c,#4f8ef7)">RZ</div>
+          <div>
+            <div class="task-name">AI Planner chat UI</div>
+            <div style="font-size:0.72rem;color:var(--muted)">Assigned to Ryan</div>
+          </div>
+          <div class="task-due">Due Apr 20</div>
+          <div class="task-status" style="background:rgba(255,85,85,0.15);color:var(--red)">Not Started</div>
+        </div>
+      </div>
+
+    </div>
+  </div>
+</div>
+
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+</body>
+</html>

--- a/mock_pages/login.html
+++ b/mock_pages/login.html
@@ -1,0 +1,370 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+  <title>StudySync — Login</title>
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet"/>
+  <link href="https://fonts.googleapis.com/css2?family=Sora:wght@300;400;600;700&family=DM+Sans:ital,wght@0,300;0,400;0,500;1,300&display=swap" rel="stylesheet"/>
+  <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" rel="stylesheet"/>
+  <style>
+    :root {
+      --navy: #0d1b2a;
+      --navy2: #1b2d42;
+      --card: #162032;
+      --accent: #4f8ef7;
+      --accent2: #7c5cfc;
+      --orange: #ff6b35;
+      --pink: #e040fb;
+      --text: #e8edf5;
+      --muted: #7a8fa6;
+      --border: rgba(255,255,255,0.08);
+    }
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+    body {
+      font-family: 'DM Sans', sans-serif;
+      background: var(--navy);
+      color: var(--text);
+      min-height: 100vh;
+      display: flex;
+    }
+
+    /* Left panel */
+    .left-panel {
+      width: 55%;
+      background: linear-gradient(135deg, #0d1b2a 0%, #1a2744 50%, #0f2340 100%);
+      display: flex;
+      flex-direction: column;
+      justify-content: center;
+      align-items: flex-start;
+      padding: 60px 70px;
+      position: relative;
+      overflow: hidden;
+    }
+    .left-panel::before {
+      content: '';
+      position: absolute;
+      width: 500px; height: 500px;
+      border-radius: 50%;
+      background: radial-gradient(circle, rgba(79,142,247,0.15) 0%, transparent 70%);
+      top: -100px; left: -100px;
+    }
+    .left-panel::after {
+      content: '';
+      position: absolute;
+      width: 400px; height: 400px;
+      border-radius: 50%;
+      background: radial-gradient(circle, rgba(124,92,252,0.12) 0%, transparent 70%);
+      bottom: -80px; right: 30px;
+    }
+
+    .brand {
+      font-family: 'Sora', sans-serif;
+      font-weight: 700;
+      font-size: 1.8rem;
+      color: var(--accent);
+      margin-bottom: 60px;
+      display: flex;
+      align-items: center;
+      gap: 10px;
+      z-index: 1;
+    }
+    .brand i { font-size: 1.5rem; }
+
+    .hero-text {
+      z-index: 1;
+    }
+    .hero-text h1 {
+      font-family: 'Sora', sans-serif;
+      font-weight: 700;
+      font-size: 2.8rem;
+      line-height: 1.2;
+      margin-bottom: 20px;
+      color: #fff;
+    }
+    .hero-text h1 span {
+      background: linear-gradient(90deg, var(--accent), var(--accent2));
+      -webkit-background-clip: text;
+      -webkit-text-fill-color: transparent;
+    }
+    .hero-text p {
+      font-size: 1.05rem;
+      color: var(--muted);
+      line-height: 1.7;
+      max-width: 400px;
+      margin-bottom: 40px;
+    }
+
+    .feature-pills {
+      display: flex;
+      flex-direction: column;
+      gap: 14px;
+      z-index: 1;
+    }
+    .pill {
+      display: flex;
+      align-items: center;
+      gap: 12px;
+      background: rgba(255,255,255,0.05);
+      border: 1px solid var(--border);
+      border-radius: 12px;
+      padding: 12px 18px;
+      font-size: 0.9rem;
+      backdrop-filter: blur(10px);
+    }
+    .pill-icon {
+      width: 34px; height: 34px;
+      border-radius: 8px;
+      display: flex; align-items: center; justify-content: center;
+      font-size: 0.95rem;
+      flex-shrink: 0;
+    }
+
+    /* Right panel (form) */
+    .right-panel {
+      width: 45%;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      padding: 60px 50px;
+      background: var(--card);
+    }
+
+    .auth-box { width: 100%; max-width: 400px; }
+
+    .tab-switcher {
+      display: flex;
+      background: rgba(255,255,255,0.05);
+      border-radius: 10px;
+      padding: 4px;
+      margin-bottom: 32px;
+    }
+    .tab-btn {
+      flex: 1;
+      padding: 10px;
+      border: none;
+      background: transparent;
+      color: var(--muted);
+      font-family: 'DM Sans', sans-serif;
+      font-size: 0.95rem;
+      font-weight: 500;
+      border-radius: 8px;
+      cursor: pointer;
+      transition: all 0.25s;
+    }
+    .tab-btn.active {
+      background: var(--accent);
+      color: #fff;
+    }
+
+    .form-label {
+      font-size: 0.82rem;
+      font-weight: 500;
+      color: var(--muted);
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+      margin-bottom: 6px;
+    }
+    .form-control {
+      background: rgba(255,255,255,0.05) !important;
+      border: 1px solid var(--border) !important;
+      color: var(--text) !important;
+      border-radius: 10px !important;
+      padding: 12px 16px !important;
+      font-family: 'DM Sans', sans-serif;
+      font-size: 0.95rem;
+      transition: border-color 0.2s, box-shadow 0.2s;
+    }
+    .form-control:focus {
+      border-color: var(--accent) !important;
+      box-shadow: 0 0 0 3px rgba(79,142,247,0.15) !important;
+      outline: none;
+    }
+    .form-control::placeholder { color: var(--muted) !important; }
+
+    .input-group-text {
+      background: rgba(255,255,255,0.05) !important;
+      border: 1px solid var(--border) !important;
+      border-right: none !important;
+      color: var(--muted) !important;
+      border-radius: 10px 0 0 10px !important;
+    }
+    .input-group .form-control { border-left: none !important; border-radius: 0 10px 10px 0 !important; }
+
+    .btn-primary-custom {
+      background: linear-gradient(135deg, var(--accent), var(--accent2));
+      border: none;
+      color: white;
+      font-family: 'Sora', sans-serif;
+      font-weight: 600;
+      font-size: 0.95rem;
+      padding: 13px;
+      border-radius: 10px;
+      width: 100%;
+      cursor: pointer;
+      transition: opacity 0.2s, transform 0.1s;
+      letter-spacing: 0.02em;
+    }
+    .btn-primary-custom:hover { opacity: 0.9; transform: translateY(-1px); }
+    .btn-primary-custom:active { transform: translateY(0); }
+
+    .divider {
+      display: flex; align-items: center; gap: 12px;
+      color: var(--muted); font-size: 0.82rem; margin: 22px 0;
+    }
+    .divider::before, .divider::after {
+      content: ''; flex: 1; height: 1px; background: var(--border);
+    }
+
+    .btn-outline-custom {
+      background: transparent;
+      border: 1px solid var(--border);
+      color: var(--text);
+      font-family: 'DM Sans', sans-serif;
+      font-size: 0.9rem;
+      padding: 11px;
+      border-radius: 10px;
+      width: 100%;
+      cursor: pointer;
+      transition: background 0.2s;
+      display: flex; align-items: center; justify-content: center; gap: 8px;
+    }
+    .btn-outline-custom:hover { background: rgba(255,255,255,0.06); }
+
+    .auth-footer { text-align: center; margin-top: 24px; font-size: 0.85rem; color: var(--muted); }
+    .auth-footer a { color: var(--accent); text-decoration: none; }
+
+    .mb-4-custom { margin-bottom: 18px; }
+
+    /* Register panel (hidden by default) */
+    #registerForm { display: none; }
+
+    @keyframes fadeIn { from { opacity: 0; transform: translateY(8px); } to { opacity: 1; transform: translateY(0); } }
+    .fade-in { animation: fadeIn 0.3s ease forwards; }
+  </style>
+</head>
+<body>
+
+  <!-- Left decorative panel -->
+  <div class="left-panel">
+    <div class="brand">
+      <i class="fas fa-calendar-alt"></i> StudySync
+    </div>
+    <div class="hero-text">
+      <h1>Your campus life,<br/><span>smartly organised.</span></h1>
+      <p>Timetable management, AI-powered study planning, and team collaboration — all in one place.</p>
+    </div>
+    <div class="feature-pills">
+      <div class="pill">
+        <div class="pill-icon" style="background:rgba(79,142,247,0.15);color:var(--accent)"><i class="fas fa-calendar-week"></i></div>
+        <span>Visual weekly timetable with exam tracking</span>
+      </div>
+      <div class="pill">
+        <div class="pill-icon" style="background:rgba(124,92,252,0.15);color:var(--accent2)"><i class="fas fa-robot"></i></div>
+        <span>AI study planner that schedules your revision</span>
+      </div>
+      <div class="pill">
+        <div class="pill-icon" style="background:rgba(224,64,251,0.15);color:var(--pink)"><i class="fas fa-users"></i></div>
+        <span>See your group's schedule &amp; find meeting times</span>
+      </div>
+    </div>
+  </div>
+
+  <!-- Right auth panel -->
+  <div class="right-panel">
+    <div class="auth-box">
+      <h2 style="font-family:'Sora',sans-serif;font-weight:700;font-size:1.6rem;margin-bottom:8px;">Welcome back</h2>
+      <p style="color:var(--muted);font-size:0.9rem;margin-bottom:28px;">Sign in to your StudySync account</p>
+
+      <div class="tab-switcher">
+        <button class="tab-btn active" onclick="switchTab('login')">Sign In</button>
+        <button class="tab-btn" onclick="switchTab('register')">Create Account</button>
+      </div>
+
+      <!-- LOGIN FORM -->
+      <div id="loginForm" class="fade-in">
+        <div class="mb-4-custom">
+          <label class="form-label">Email Address</label>
+          <div class="input-group">
+            <span class="input-group-text"><i class="fas fa-envelope"></i></span>
+            <input type="email" class="form-control" placeholder="you@student.uwa.edu.au" />
+          </div>
+        </div>
+        <div class="mb-4-custom">
+          <label class="form-label">Password</label>
+          <div class="input-group">
+            <span class="input-group-text"><i class="fas fa-lock"></i></span>
+            <input type="password" class="form-control" placeholder="••••••••" />
+          </div>
+        </div>
+        <div style="text-align:right;margin-bottom:20px;">
+          <a href="#" style="color:var(--accent);font-size:0.85rem;text-decoration:none;">Forgot password?</a>
+        </div>
+        <button class="btn-primary-custom" onclick="window.location.href='timetable.html'">
+          Sign In &nbsp;<i class="fas fa-arrow-right"></i>
+        </button>
+        <div class="divider">or continue with</div>
+        <button class="btn-outline-custom">
+          <img src="https://www.google.com/favicon.ico" width="16" height="16"/> Google
+        </button>
+      </div>
+
+      <!-- REGISTER FORM -->
+      <div id="registerForm">
+        <div class="mb-4-custom">
+          <label class="form-label">Full Name</label>
+          <div class="input-group">
+            <span class="input-group-text"><i class="fas fa-user"></i></span>
+            <input type="text" class="form-control" placeholder="Jane Smith" />
+          </div>
+        </div>
+        <div class="mb-4-custom">
+          <label class="form-label">Student ID</label>
+          <div class="input-group">
+            <span class="input-group-text"><i class="fas fa-id-card"></i></span>
+            <input type="text" class="form-control" placeholder="23XXXXXX" />
+          </div>
+        </div>
+        <div class="mb-4-custom">
+          <label class="form-label">Email Address</label>
+          <div class="input-group">
+            <span class="input-group-text"><i class="fas fa-envelope"></i></span>
+            <input type="email" class="form-control" placeholder="you@student.uwa.edu.au" />
+          </div>
+        </div>
+        <div class="mb-4-custom">
+          <label class="form-label">Password</label>
+          <div class="input-group">
+            <span class="input-group-text"><i class="fas fa-lock"></i></span>
+            <input type="password" class="form-control" placeholder="Min. 8 characters" />
+          </div>
+        </div>
+        <button class="btn-primary-custom" onclick="window.location.href='timetable.html'">
+          Create Account &nbsp;<i class="fas fa-arrow-right"></i>
+        </button>
+      </div>
+
+    </div>
+  </div>
+
+  <script>
+    function switchTab(tab) {
+      const btns = document.querySelectorAll('.tab-btn');
+      btns.forEach(b => b.classList.remove('active'));
+      if (tab === 'login') {
+        btns[0].classList.add('active');
+        document.getElementById('loginForm').style.display = 'block';
+        document.getElementById('registerForm').style.display = 'none';
+        document.querySelector('h2').textContent = 'Welcome back';
+        document.querySelector('.right-panel p').textContent = 'Sign in to your StudySync account';
+      } else {
+        btns[1].classList.add('active');
+        document.getElementById('loginForm').style.display = 'none';
+        document.getElementById('registerForm').style.display = 'block';
+        document.querySelector('h2').textContent = 'Get started';
+        document.querySelector('.right-panel p').textContent = 'Create your free StudySync account';
+      }
+    }
+  </script>
+</body>
+</html>

--- a/mock_pages/timetable.html
+++ b/mock_pages/timetable.html
@@ -1,0 +1,507 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8"/>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+  <title>StudySync — Timetable</title>
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet"/>
+  <link href="https://fonts.googleapis.com/css2?family=Sora:wght@300;400;600;700&family=DM+Sans:ital,wght@0,300;0,400;0,500;1,300&display=swap" rel="stylesheet"/>
+  <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" rel="stylesheet"/>
+  <style>
+    :root {
+      --navy: #0d1b2a;
+      --navy2: #1b2d42;
+      --card: #111f30;
+      --sidebar: #0f1e2e;
+      --accent: #4f8ef7;
+      --accent2: #7c5cfc;
+      --orange: #ff6b35;
+      --pink: #e040fb;
+      --green: #26d07c;
+      --yellow: #ffc94a;
+      --text: #e8edf5;
+      --muted: #6b839e;
+      --border: rgba(255,255,255,0.07);
+    }
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+    body { font-family: 'DM Sans', sans-serif; background: var(--navy); color: var(--text); display: flex; height: 100vh; overflow: hidden; }
+
+    /* SIDEBAR */
+    .sidebar {
+      width: 220px;
+      background: var(--sidebar);
+      border-right: 1px solid var(--border);
+      display: flex;
+      flex-direction: column;
+      padding: 24px 0;
+      flex-shrink: 0;
+    }
+    .brand {
+      font-family: 'Sora', sans-serif;
+      font-weight: 700;
+      font-size: 1.2rem;
+      color: var(--accent);
+      padding: 0 22px;
+      margin-bottom: 32px;
+      display: flex; align-items: center; gap: 8px;
+    }
+    .nav-section-label {
+      font-size: 0.68rem;
+      font-weight: 600;
+      letter-spacing: 0.1em;
+      color: var(--muted);
+      text-transform: uppercase;
+      padding: 0 22px;
+      margin: 18px 0 8px;
+    }
+    .nav-item {
+      display: flex; align-items: center; gap: 10px;
+      padding: 10px 22px;
+      font-size: 0.88rem;
+      font-weight: 500;
+      color: var(--muted);
+      cursor: pointer;
+      transition: all 0.2s;
+      text-decoration: none;
+      border-radius: 0;
+    }
+    .nav-item:hover, .nav-item.active {
+      color: var(--text);
+      background: rgba(79,142,247,0.1);
+    }
+    .nav-item.active { color: var(--accent); border-right: 2px solid var(--accent); }
+    .nav-item i { width: 18px; text-align: center; font-size: 0.9rem; }
+
+    .sidebar-bottom {
+      margin-top: auto;
+      padding: 16px 22px;
+      border-top: 1px solid var(--border);
+    }
+    .user-chip {
+      display: flex; align-items: center; gap: 10px;
+      font-size: 0.85rem;
+    }
+    .avatar {
+      width: 32px; height: 32px; border-radius: 50%;
+      background: linear-gradient(135deg, var(--accent), var(--accent2));
+      display: flex; align-items: center; justify-content: center;
+      font-size: 0.75rem; font-weight: 700; color: white;
+      flex-shrink: 0;
+    }
+
+    /* MAIN CONTENT */
+    .main { flex: 1; display: flex; flex-direction: column; overflow: hidden; }
+
+    .topbar {
+      padding: 16px 28px;
+      border-bottom: 1px solid var(--border);
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 16px;
+      background: var(--card);
+    }
+    .topbar-left { display: flex; align-items: center; gap: 16px; }
+    .page-title { font-family: 'Sora', sans-serif; font-weight: 700; font-size: 1.4rem; }
+
+    .view-toggle {
+      display: flex;
+      background: rgba(255,255,255,0.05);
+      border-radius: 8px;
+      padding: 3px;
+    }
+    .view-btn {
+      padding: 6px 12px;
+      border: none;
+      background: transparent;
+      color: var(--muted);
+      font-size: 0.8rem;
+      border-radius: 6px;
+      cursor: pointer;
+      transition: all 0.2s;
+    }
+    .view-btn.active { background: var(--accent); color: white; }
+
+    .nav-arrows { display: flex; align-items: center; gap: 6px; }
+    .arrow-btn {
+      width: 32px; height: 32px;
+      background: rgba(255,255,255,0.05);
+      border: 1px solid var(--border);
+      border-radius: 8px;
+      color: var(--muted);
+      cursor: pointer;
+      display: flex; align-items: center; justify-content: center;
+      transition: all 0.2s;
+      font-size: 0.8rem;
+    }
+    .arrow-btn:hover { background: rgba(255,255,255,0.1); color: var(--text); }
+    .date-range {
+      font-size: 0.9rem; font-weight: 500; color: var(--text);
+      background: rgba(255,255,255,0.05);
+      border: 1px solid var(--border);
+      border-radius: 8px;
+      padding: 6px 14px;
+    }
+
+    .btn-create {
+      background: var(--accent);
+      border: none;
+      color: white;
+      font-family: 'DM Sans', sans-serif;
+      font-size: 0.85rem;
+      font-weight: 600;
+      padding: 8px 16px;
+      border-radius: 8px;
+      cursor: pointer;
+      display: flex; align-items: center; gap: 6px;
+      transition: opacity 0.2s;
+    }
+    .btn-create:hover { opacity: 0.85; }
+
+    /* FILTER TAGS */
+    .filter-bar {
+      padding: 10px 28px;
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      border-bottom: 1px solid var(--border);
+      background: var(--card);
+      flex-wrap: wrap;
+    }
+    .filter-icon {
+      width: 30px; height: 30px;
+      background: rgba(255,255,255,0.06);
+      border: 1px solid var(--border);
+      border-radius: 7px;
+      display: flex; align-items: center; justify-content: center;
+      font-size: 0.8rem; color: var(--muted); cursor: pointer;
+    }
+    .filter-tag {
+      padding: 5px 14px;
+      border-radius: 20px;
+      font-size: 0.78rem;
+      font-weight: 600;
+      cursor: pointer;
+      transition: opacity 0.2s;
+      border: none;
+    }
+    .filter-tag:hover { opacity: 0.8; }
+    .tag-lecture    { background: rgba(79,142,247,0.2);  color: var(--accent); }
+    .tag-lab        { background: rgba(255,107,53,0.2);  color: var(--orange); }
+    .tag-tutorial   { background: rgba(224,64,251,0.2);  color: var(--pink); }
+    .tag-exam       { background: rgba(255,50,50,0.2);   color: #ff5555; }
+    .tag-assignment { background: rgba(38,208,124,0.2);  color: var(--green); }
+    .tag-workshop   { background: rgba(255,201,74,0.2);  color: var(--yellow); }
+
+    /* CALENDAR GRID */
+    .calendar-wrap { flex: 1; overflow-y: auto; padding: 0 28px 28px; }
+    .calendar-grid {
+      display: grid;
+      grid-template-columns: 72px repeat(5, 1fr);
+      border: 1px solid var(--border);
+      border-radius: 12px;
+      overflow: hidden;
+      margin-top: 20px;
+      background: var(--card);
+    }
+
+    .day-header {
+      text-align: center;
+      padding: 14px 8px;
+      font-size: 0.8rem;
+      font-weight: 600;
+      color: var(--muted);
+      text-transform: uppercase;
+      letter-spacing: 0.06em;
+      border-bottom: 1px solid var(--border);
+      background: rgba(255,255,255,0.02);
+    }
+    .day-header.today { color: var(--accent); }
+    .day-header .date-num {
+      display: block;
+      font-size: 1.2rem;
+      font-weight: 700;
+      color: var(--text);
+      margin-top: 2px;
+    }
+    .day-header.today .date-num {
+      background: var(--accent);
+      color: white;
+      width: 32px; height: 32px;
+      border-radius: 50%;
+      display: flex; align-items: center; justify-content: center;
+      margin: 4px auto 0;
+      font-size: 1rem;
+    }
+
+    .time-col {
+      border-right: 1px solid var(--border);
+    }
+    .time-slot {
+      height: 80px;
+      border-bottom: 1px solid var(--border);
+      display: flex;
+      align-items: flex-start;
+      justify-content: center;
+      padding-top: 8px;
+      font-size: 0.72rem;
+      color: var(--muted);
+      font-weight: 500;
+    }
+
+    .day-col {
+      border-right: 1px solid var(--border);
+      position: relative;
+    }
+    .day-col:last-child { border-right: none; }
+
+    .cell {
+      height: 80px;
+      border-bottom: 1px solid var(--border);
+      position: relative;
+      padding: 4px;
+    }
+
+    /* Events */
+    .event {
+      border-radius: 8px;
+      padding: 6px 8px;
+      font-size: 0.75rem;
+      cursor: pointer;
+      overflow: hidden;
+      transition: filter 0.15s, transform 0.15s;
+      position: absolute;
+      left: 4px; right: 4px;
+    }
+    .event:hover { filter: brightness(1.1); transform: scale(1.01); }
+    .event-title { font-weight: 700; margin-bottom: 2px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+    .event-sub { color: rgba(255,255,255,0.7); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; font-size: 0.7rem; }
+    .event-loc { font-size: 0.68rem; color: rgba(255,255,255,0.55); margin-top: 2px; }
+
+    .ev-lecture  { background: rgba(79,142,247,0.25); border-left: 3px solid var(--accent); color: var(--text); }
+    .ev-lab      { background: rgba(255,107,53,0.25); border-left: 3px solid var(--orange); color: var(--text); }
+    .ev-tutorial { background: rgba(224,64,251,0.25); border-left: 3px solid var(--pink); color: var(--text); }
+    .ev-exam     { background: rgba(255,50,50,0.25);  border-left: 3px solid #ff5555; color: var(--text); }
+
+    /* tall events */
+    .event.tall-2 { height: calc(160px - 12px); top: 4px; }
+    .event.tall-1 { height: calc(80px - 8px);   top: 4px; }
+
+    /* scrollbar */
+    .calendar-wrap::-webkit-scrollbar { width: 6px; }
+    .calendar-wrap::-webkit-scrollbar-track { background: transparent; }
+    .calendar-wrap::-webkit-scrollbar-thumb { background: var(--border); border-radius: 3px; }
+  </style>
+</head>
+<body>
+
+<!-- SIDEBAR -->
+<nav class="sidebar">
+  <div class="brand"><i class="fas fa-calendar-alt"></i> StudySync</div>
+  <span class="nav-section-label">Main</span>
+  <a href="timetable.html" class="nav-item active"><i class="fas fa-calendar-week"></i> Timetable</a>
+  <a href="ai_planner.html" class="nav-item"><i class="fas fa-robot"></i> AI Planner</a>
+  <a href="group.html" class="nav-item"><i class="fas fa-users"></i> My Group</a>
+  <span class="nav-section-label">Personal</span>
+  <a href="#" class="nav-item"><i class="fas fa-book-open"></i> Courses</a>
+  <a href="exam_detail.html" class="nav-item"><i class="fas fa-file-alt"></i> Exams &amp; Tasks</a>
+  <a href="#" class="nav-item"><i class="fas fa-bell"></i> Reminders</a>
+  <span class="nav-section-label">Settings</span>
+  <a href="#" class="nav-item"><i class="fas fa-cog"></i> Preferences</a>
+  <div class="sidebar-bottom">
+    <div class="user-chip">
+      <div class="avatar">JS</div>
+      <div>
+        <div style="font-size:0.82rem;font-weight:600;">Jane Smith</div>
+        <div style="font-size:0.72rem;color:var(--muted);">23456789</div>
+      </div>
+    </div>
+  </div>
+</nav>
+
+<!-- MAIN -->
+<div class="main">
+  <!-- TOPBAR -->
+  <div class="topbar">
+    <div class="topbar-left">
+      <div class="page-title">Timetable</div>
+      <div class="view-toggle">
+        <button class="view-btn active"><i class="fas fa-th"></i></button>
+        <button class="view-btn"><i class="fas fa-bars"></i></button>
+      </div>
+      <div class="nav-arrows">
+        <button class="arrow-btn"><i class="fas fa-chevron-left"></i></button>
+        <button class="arrow-btn"><i class="fas fa-chevron-right"></i></button>
+      </div>
+      <div class="date-range"><i class="fas fa-calendar" style="margin-right:6px;color:var(--muted)"></i>14 – 18 April 2026</div>
+    </div>
+    <button class="btn-create" onclick="window.location.href='exam_detail.html'">
+      <i class="fas fa-plus"></i> Create Event
+    </button>
+  </div>
+
+  <!-- FILTER BAR -->
+  <div class="filter-bar">
+    <div class="filter-icon"><i class="fas fa-filter"></i></div>
+    <button class="filter-tag tag-lecture">Lecture</button>
+    <button class="filter-tag tag-lab">Laboratory</button>
+    <button class="filter-tag tag-tutorial">Tutorial</button>
+    <button class="filter-tag tag-exam">Exam</button>
+    <button class="filter-tag tag-assignment">Assignment</button>
+    <button class="filter-tag tag-workshop">Workshop</button>
+  </div>
+
+  <!-- CALENDAR -->
+  <div class="calendar-wrap">
+    <div class="calendar-grid">
+
+      <!-- HEADER ROW -->
+      <div class="day-header" style="background:rgba(255,255,255,0.02);border-bottom:1px solid var(--border);"></div>
+      <div class="day-header"><span>Mon</span><span class="date-num">14</span></div>
+      <div class="day-header today"><span>Tue</span><span class="date-num">15</span></div>
+      <div class="day-header"><span>Wed</span><span class="date-num">16</span></div>
+      <div class="day-header"><span>Thu</span><span class="date-num">17</span></div>
+      <div class="day-header"><span>Fri</span><span class="date-num">18</span></div>
+
+      <!-- 8 AM -->
+      <div class="time-col"><div class="time-slot">8 AM</div></div>
+      <div class="day-col"><div class="cell"></div></div>
+      <div class="day-col"><div class="cell"></div></div>
+      <div class="day-col"><div class="cell"></div></div>
+      <div class="day-col"><div class="cell"></div></div>
+      <div class="day-col"><div class="cell"></div></div>
+
+      <!-- 9 AM -->
+      <div class="time-col"><div class="time-slot">9 AM</div></div>
+      <div class="day-col">
+        <div class="cell" style="height:160px;position:relative;">
+          <div class="event ev-lab tall-2" onclick="window.location.href='exam_detail.html'">
+            <div class="event-title">CITS3403</div>
+            <div class="event-sub">Laboratory</div>
+            <div class="event-loc"><i class="fas fa-map-marker-alt"></i> Lab 1.06</div>
+          </div>
+        </div>
+      </div>
+      <div class="day-col">
+        <div class="cell">
+          <div class="event ev-lecture tall-1">
+            <div class="event-title">CITS3403</div>
+            <div class="event-sub">Lecture — Web Dev</div>
+            <div class="event-loc"><i class="fas fa-map-marker-alt"></i> LT 225</div>
+          </div>
+        </div>
+      </div>
+      <div class="day-col">
+        <div class="cell">
+          <div class="event ev-lecture tall-1">
+            <div class="event-title">MATH2004</div>
+            <div class="event-sub">Lecture — Linear Alg</div>
+            <div class="event-loc"><i class="fas fa-map-marker-alt"></i> LT 120</div>
+          </div>
+        </div>
+      </div>
+      <div class="day-col"><div class="cell"></div></div>
+      <div class="day-col"><div class="cell"></div></div>
+
+      <!-- 10 AM -->
+      <div class="time-col"><div class="time-slot">10 AM</div></div>
+      <div class="day-col"><div class="cell" style="height:160px"></div></div>
+      <div class="day-col">
+        <div class="cell">
+          <div class="event ev-exam tall-1" onclick="window.location.href='exam_detail.html'">
+            <div class="event-title">⚠️ Mid-sem Test</div>
+            <div class="event-sub">CITS3403 — Room 106</div>
+          </div>
+        </div>
+      </div>
+      <div class="day-col"><div class="cell"></div></div>
+      <div class="day-col">
+        <div class="cell">
+          <div class="event ev-tutorial tall-1">
+            <div class="event-title">CITS3403</div>
+            <div class="event-sub">Tutorial — Group 02</div>
+            <div class="event-loc"><i class="fas fa-map-marker-alt"></i> Reid 115</div>
+          </div>
+        </div>
+      </div>
+      <div class="day-col"><div class="cell"></div></div>
+
+      <!-- 11 AM -->
+      <div class="time-col"><div class="time-slot">11 AM</div></div>
+      <div class="day-col"><div class="cell"></div></div>
+      <div class="day-col"><div class="cell"></div></div>
+      <div class="day-col">
+        <div class="cell">
+          <div class="event ev-tutorial tall-1">
+            <div class="event-title">MATH2004</div>
+            <div class="event-sub">Tutorial</div>
+            <div class="event-loc"><i class="fas fa-map-marker-alt"></i> Blg 205</div>
+          </div>
+        </div>
+      </div>
+      <div class="day-col"><div class="cell"></div></div>
+      <div class="day-col"><div class="cell"></div></div>
+
+      <!-- 12 PM -->
+      <div class="time-col"><div class="time-slot">12 PM</div></div>
+      <div class="day-col"><div class="cell"></div></div>
+      <div class="day-col"><div class="cell"></div></div>
+      <div class="day-col"><div class="cell"></div></div>
+      <div class="day-col"><div class="cell"></div></div>
+      <div class="day-col"><div class="cell"></div></div>
+
+      <!-- 1 PM -->
+      <div class="time-col"><div class="time-slot">1 PM</div></div>
+      <div class="day-col"><div class="cell"></div></div>
+      <div class="day-col">
+        <div class="cell">
+          <div class="event ev-lecture tall-1">
+            <div class="event-title">STAT2402</div>
+            <div class="event-sub">Lecture</div>
+            <div class="event-loc"><i class="fas fa-map-marker-alt"></i> LT 330</div>
+          </div>
+        </div>
+      </div>
+      <div class="day-col"><div class="cell"></div></div>
+      <div class="day-col">
+        <div class="cell">
+          <div class="event ev-lecture tall-1">
+            <div class="event-title">STAT2402</div>
+            <div class="event-sub">Lecture</div>
+            <div class="event-loc"><i class="fas fa-map-marker-alt"></i> LT 330</div>
+          </div>
+        </div>
+      </div>
+      <div class="day-col"><div class="cell"></div></div>
+
+      <!-- 2 PM -->
+      <div class="time-col"><div class="time-slot">2 PM</div></div>
+      <div class="day-col"><div class="cell"></div></div>
+      <div class="day-col"><div class="cell"></div></div>
+      <div class="day-col"><div class="cell"></div></div>
+      <div class="day-col"><div class="cell"></div></div>
+      <div class="day-col"><div class="cell"></div></div>
+
+      <!-- 3 PM -->
+      <div class="time-col"><div class="time-slot">3 PM</div></div>
+      <div class="day-col"><div class="cell"></div></div>
+      <div class="day-col"><div class="cell"></div></div>
+      <div class="day-col">
+        <div class="cell" style="height:160px;position:relative;">
+          <div class="event ev-lab tall-2">
+            <div class="event-title">STAT2402</div>
+            <div class="event-sub">Laboratory</div>
+            <div class="event-loc"><i class="fas fa-map-marker-alt"></i> Stats Lab</div>
+          </div>
+        </div>
+      </div>
+      <div class="day-col"><div class="cell"></div></div>
+      <div class="day-col"><div class="cell"></div></div>
+
+    </div><!-- end grid -->
+  </div><!-- end calendar-wrap -->
+</div><!-- end main -->
+
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## What
Adds a **static mock** for the application **source / landing page**: layout, Bootstrap (or chosen CSS framework) grid, and placeholder content. Prepares Checkpoint 2 “Planning and Frontend UI” deliverable before Flask + Jinja wiring.

## Why
- Lock in **navigation and visual hierarchy** early.
- Gives the team a **shared reference** for later templates and AJAX endpoints.

## Changes
- New static HTML for source/landing page (file names as committed, e.g. `source.html` + shared styles if any).
- Placeholder sections: hero, feature cards, optional “community teaser”, footer.

## How to review
1. Open the HTML file in a browser (or `python -m http.server` from repo root if paths are relative).
2. Resize window — confirm responsive behaviour.
3. Check HTML structure is ready to be **split into Jinja blocks** later (`extends`, `{% block %}`) without a full rewrite.

## Testing
- [ ] Manual: open page, no broken assets, no JS errors (if any script included).
- [ ] N/A: automated tests (static mock only).

## Related
Closes #7 

## Checklist
- [ ] Uses only **allowed** stack for styling (Bootstrap / Tailwind / etc. per brief).
- [ ] No secrets or real credentials in HTML.