### PR TITLE
feat(groups): book common free slot as calendar event

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,41 @@
 # AgileWebDevLab
-This repo is used for Agile Web Development exercises.
+
+Repository for Agile Web Development coursework (lab submission).
+
+## Issue #1 slice: Book common free slot → calendar event
+
+This branch adds a **minimal runnable Flask app** (not the full StudySync draft) that implements the group feature from **Issue #1**: members see **common free time** for the current week, and **Book** persists a `CalendarEvent` for the **logged-in user** only (`event_type=group_study`), with JSON APIs, **CSRF** on mutating requests, and **SQLAlchemy** on SQLite under `instance/lab.db` (created on first run; `instance/` is gitignored).
+
+Static UI mocks remain under `mock_pages/` for reference.
+
+## Prerequisites
+
+- Python 3.11+ (tested with 3.13)
+
+## Setup and run
+
+```bash
+python3 -m venv .venv
+source .venv/bin/activate
+pip install -r requirements.txt
+python run.py
+```
+
+Open **http://127.0.0.1:5000/** — you will be redirected to log in, then to **/group/1**.
+
+### Seeded demo accounts
+
+| Email            | Password   |
+|------------------|------------|
+| `alice@lab.local` | `labdemo123` |
+| `bob@lab.local`   | `labdemo123` |
+
+Both users belong to **Demo Lab Group** (join code `LABDEMO1`). Seeded calendar events leave **common free slots** you can book from the UI.
+
+## Tests
+
+```bash
+pytest
+```
+
+Uses a temporary SQLite file per test run (`WTF_CSRF_ENABLED=False` in the test app only).

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,0 +1,102 @@
+from __future__ import annotations
+
+import os
+from datetime import date, datetime, time, timedelta
+from pathlib import Path
+
+from flask import Flask, redirect, url_for
+
+from app.config import Config
+from app.extensions import csrf, db, login_manager
+
+
+def _seed_demo_data() -> None:
+    from app.models import CalendarEvent, GroupMember, StudyGroup, User
+
+    if User.query.filter_by(email="alice@lab.local").first() is not None:
+        return
+
+    alice = User(email="alice@lab.local", full_name="Alice Lab")
+    alice.set_password("labdemo123")
+    bob = User(email="bob@lab.local", full_name="Bob Lab")
+    bob.set_password("labdemo123")
+    db.session.add_all([alice, bob])
+    db.session.flush()
+
+    g = StudyGroup(name="Demo Lab Group", join_code="LABDEMO1", created_by_user_id=alice.id)
+    db.session.add(g)
+    db.session.flush()
+    db.session.add_all(
+        [
+            GroupMember(group_id=g.id, user_id=alice.id, role="owner"),
+            GroupMember(group_id=g.id, user_id=bob.id, role="member"),
+        ]
+    )
+
+    monday = date.today() - timedelta(days=date.today().weekday())
+    # Bob busy Mon 10:00–12:00; Alice busy Mon 14:00–16:00 → common free includes Mon 12:00–14:00 etc.
+    db.session.add(
+        CalendarEvent(
+            user_id=bob.id,
+            title="Lecture (seed)",
+            event_type="class",
+            start_at=datetime.combine(monday, time(10, 0)),
+            end_at=datetime.combine(monday, time(12, 0)),
+        )
+    )
+    db.session.add(
+        CalendarEvent(
+            user_id=alice.id,
+            title="Tutorial (seed)",
+            event_type="class",
+            start_at=datetime.combine(monday, time(14, 0)),
+            end_at=datetime.combine(monday, time(16, 0)),
+        )
+    )
+    db.session.commit()
+
+
+def create_app(config_object: type = Config) -> Flask:
+    root = Path(__file__).resolve().parent.parent
+    os.makedirs(root / "instance", exist_ok=True)
+
+    app = Flask(
+        __name__,
+        instance_relative_config=False,
+        template_folder=str(root / "templates"),
+        static_folder=str(root / "static"),
+    )
+    app.config.from_object(config_object)
+
+    db.init_app(app)
+    login_manager.init_app(app)
+    csrf.init_app(app)
+    login_manager.login_view = "auth.login_page"
+
+    from flask import jsonify, request
+
+    @login_manager.unauthorized_handler
+    def _unauthorized():
+        if request.path.startswith("/api/"):
+            return jsonify({"error": "Unauthorized"}), 401
+        from flask import redirect, url_for
+
+        return redirect(url_for("auth.login_page", next=request.url))
+
+    from app import models  # noqa: F401
+
+    from app.blueprints.auth import bp as auth_bp
+    from app.blueprints.group_book import bp as group_book_bp
+
+    app.register_blueprint(auth_bp)
+    app.register_blueprint(group_book_bp)
+
+    @app.get("/")
+    def index():
+        return redirect(url_for("group_book.group_page", group_id=1))
+
+    with app.app_context():
+        db.create_all()
+        _seed_demo_data()
+
+    return app

--- a/app/blueprints/auth.py
+++ b/app/blueprints/auth.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+from flask import Blueprint, flash, redirect, render_template, request, url_for
+from flask_login import login_required, login_user, logout_user
+
+from app.extensions import db
+from app.models import User
+
+bp = Blueprint("auth", __name__)
+
+
+@bp.get("/login")
+def login_page():
+    if request.args.get("next"):
+        pass
+    return render_template("login.html")
+
+
+@bp.post("/login")
+def login_post():
+    email = (request.form.get("email") or "").strip().lower()
+    password = request.form.get("password") or ""
+    user = User.query.filter_by(email=email).first()
+    if user is None or not user.check_password(password):
+        flash("Invalid email or password.", "danger")
+        return redirect(url_for("auth.login_page"))
+    login_user(user, remember=True)
+    nxt = request.args.get("next") or url_for("group_book.group_page", group_id=1)
+    return redirect(nxt)
+
+
+@bp.post("/logout")
+@login_required
+def logout_post():
+    logout_user()
+    return redirect(url_for("auth.login_page"))

--- a/app/blueprints/group_book.py
+++ b/app/blueprints/group_book.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+from datetime import date, datetime
+
+from flask import Blueprint, jsonify, render_template, request
+from flask_login import current_user, login_required
+
+from app.extensions import db
+from app.models import GroupMember, StudyGroup
+from app.services.group_schedule import book_free_slot_for_user, common_free_slots, monday_of
+
+bp = Blueprint("group_book", __name__)
+
+
+def _parse_week_start(raw: str | None):
+    if not raw:
+        return None
+    try:
+        from datetime import date
+
+        d = date.fromisoformat(raw)
+    except ValueError:
+        return None
+    return monday_of(d)
+
+
+def _group_if_member(group_id: int) -> StudyGroup | None:
+    g = db.session.get(StudyGroup, group_id)
+    if g is None:
+        return None
+    if GroupMember.query.filter_by(group_id=group_id, user_id=current_user.id).first() is None:
+        return None
+    return g
+
+
+@bp.get("/group/<int:group_id>")
+@login_required
+def group_page(group_id: int):
+    if _group_if_member(group_id) is None:
+        return render_template("group_book.html", group=None, group_id=group_id), 404
+    g = db.session.get(StudyGroup, group_id)
+    week_start_iso = monday_of(date.today()).isoformat()
+    return render_template(
+        "group_book.html", group=g, group_id=group_id, week_start_iso=week_start_iso
+    )
+
+
+@bp.get("/api/groups/<int:group_id>/free-slots")
+@login_required
+def api_free_slots(group_id: int):
+    if _group_if_member(group_id) is None:
+        return jsonify({"error": "Not found."}), 404
+    ws = _parse_week_start(request.args.get("week_start"))
+    if ws is None:
+        return jsonify({"error": "Invalid or missing week_start (YYYY-MM-DD)."}), 400
+    slots = common_free_slots(group_id, ws)
+    return jsonify({"week_start": ws.isoformat(), "slots": slots})
+
+
+@bp.post("/api/groups/<int:group_id>/book-free-slot")
+@login_required
+def api_book_free_slot(group_id: int):
+    if _group_if_member(group_id) is None:
+        return jsonify({"error": "Not found."}), 404
+    if not request.is_json:
+        return jsonify({"error": "Expected application/json"}), 400
+    data = request.get_json(silent=True) or {}
+    start_raw = data.get("start")
+    end_raw = data.get("end")
+    if not start_raw or not end_raw:
+        return jsonify({"error": "start and end ISO datetimes are required."}), 400
+    try:
+        start = datetime.fromisoformat(str(start_raw).replace("Z", "+00:00"))
+        end = datetime.fromisoformat(str(end_raw).replace("Z", "+00:00"))
+    except ValueError:
+        return jsonify({"error": "Invalid start or end datetime."}), 400
+
+    ev, err = book_free_slot_for_user(user_id=current_user.id, group_id=group_id, start=start, end=end)
+    if err == "not_member":
+        return jsonify({"error": "Not found."}), 404
+    if err == "bad_time":
+        return jsonify({"error": "end must be after start."}), 400
+    if err == "not_free":
+        return jsonify({"error": "That interval is not inside a common free slot for this week."}), 409
+    if err == "conflict":
+        return jsonify({"error": "You already have an event overlapping that time."}), 409
+    assert ev is not None
+    return jsonify({"event": ev.to_dict()}), 201

--- a/app/config.py
+++ b/app/config.py
@@ -1,0 +1,11 @@
+import os
+from pathlib import Path
+
+
+class Config:
+    SECRET_KEY = os.environ.get("SECRET_KEY", "dev-lab-only-change-in-production")
+    SQLALCHEMY_DATABASE_URI = "sqlite:///" + str(
+        Path(__file__).resolve().parent.parent / "instance" / "lab.db"
+    )
+    SQLALCHEMY_TRACK_MODIFICATIONS = False
+    WTF_CSRF_HEADERS = ["X-CSRFToken", "X-CSRF-Token"]

--- a/app/extensions.py
+++ b/app/extensions.py
@@ -1,0 +1,7 @@
+from flask_login import LoginManager
+from flask_sqlalchemy import SQLAlchemy
+from flask_wtf.csrf import CSRFProtect
+
+db = SQLAlchemy()
+login_manager = LoginManager()
+csrf = CSRFProtect()

--- a/app/models.py
+++ b/app/models.py
@@ -1,0 +1,105 @@
+from __future__ import annotations
+
+from flask_login import UserMixin
+
+from app.extensions import db, login_manager
+
+
+class User(UserMixin, db.Model):
+    __tablename__ = "users"
+
+    id = db.Column(db.Integer, primary_key=True)
+    email = db.Column(db.String(255), unique=True, nullable=False, index=True)
+    password_hash = db.Column(db.String(256), nullable=False)
+    full_name = db.Column(db.String(120), nullable=False)
+
+    calendar_events = db.relationship(
+        "CalendarEvent",
+        backref="user",
+        lazy="dynamic",
+        cascade="all, delete-orphan",
+    )
+    group_memberships = db.relationship(
+        "GroupMember",
+        backref="user",
+        lazy="dynamic",
+        cascade="all, delete-orphan",
+    )
+
+    def set_password(self, password: str) -> None:
+        from werkzeug.security import generate_password_hash
+
+        self.password_hash = generate_password_hash(password)
+
+    def check_password(self, password: str) -> bool:
+        from werkzeug.security import check_password_hash
+
+        return check_password_hash(self.password_hash, password)
+
+
+class CalendarEvent(db.Model):
+    __tablename__ = "calendar_events"
+
+    id = db.Column(db.Integer, primary_key=True)
+    user_id = db.Column(db.Integer, db.ForeignKey("users.id"), nullable=False, index=True)
+    title = db.Column(db.String(200), nullable=False)
+    event_type = db.Column(db.String(32), nullable=False, default="other", index=True)
+    start_at = db.Column(db.DateTime, nullable=False, index=True)
+    end_at = db.Column(db.DateTime, nullable=False, index=True)
+    notes = db.Column(db.Text, nullable=True)
+
+    def to_dict(self) -> dict:
+        return {
+            "id": self.id,
+            "title": self.title,
+            "event_type": self.event_type,
+            "start_at": self.start_at.isoformat(timespec="minutes"),
+            "end_at": self.end_at.isoformat(timespec="minutes"),
+            "notes": self.notes or "",
+        }
+
+
+class StudyGroup(db.Model):
+    __tablename__ = "study_groups"
+
+    id = db.Column(db.Integer, primary_key=True)
+    name = db.Column(db.String(200), nullable=False)
+    join_code = db.Column(db.String(16), unique=True, nullable=False, index=True)
+    created_by_user_id = db.Column(db.Integer, db.ForeignKey("users.id"), nullable=False, index=True)
+
+    members = db.relationship(
+        "GroupMember",
+        back_populates="group",
+        lazy="dynamic",
+        cascade="all, delete-orphan",
+    )
+
+    def to_dict(self, *, include_join_code: bool = True) -> dict:
+        d = {
+            "id": self.id,
+            "name": self.name,
+            "created_by_user_id": self.created_by_user_id,
+            "member_count": self.members.count(),
+        }
+        if include_join_code:
+            d["join_code"] = self.join_code
+        return d
+
+
+class GroupMember(db.Model):
+    __tablename__ = "group_members"
+    __table_args__ = (db.UniqueConstraint("group_id", "user_id", name="uq_group_member_user"),)
+
+    id = db.Column(db.Integer, primary_key=True)
+    group_id = db.Column(db.Integer, db.ForeignKey("study_groups.id"), nullable=False, index=True)
+    user_id = db.Column(db.Integer, db.ForeignKey("users.id"), nullable=False, index=True)
+    role = db.Column(db.String(20), nullable=False, default="member")
+
+    group = db.relationship("StudyGroup", back_populates="members")
+
+
+@login_manager.user_loader
+def load_user(user_id: str) -> User | None:
+    if not user_id:
+        return None
+    return db.session.get(User, int(user_id))

--- a/app/services/group_schedule.py
+++ b/app/services/group_schedule.py
@@ -1,0 +1,130 @@
+"""Merged free slots and booking for study groups (lab slice)."""
+
+from __future__ import annotations
+
+from datetime import date, datetime, time, timedelta
+from typing import Any
+
+from app.extensions import db
+from app.models import CalendarEvent, GroupMember, User
+
+
+def monday_of(d: date) -> date:
+    return d - timedelta(days=d.weekday())
+
+
+def week_bounds_mon_fri(monday: date) -> tuple[datetime, datetime]:
+    start = datetime.combine(monday, time.min)
+    end = datetime.combine(monday + timedelta(days=5), time.min)
+    return start, end
+
+
+def _slot_busy_for_user(user_id: int, slot_start: datetime, slot_end: datetime) -> bool:
+    return (
+        CalendarEvent.query.filter_by(user_id=user_id)
+        .filter(CalendarEvent.start_at < slot_end)
+        .filter(CalendarEvent.end_at > slot_start)
+        .first()
+        is not None
+    )
+
+
+def common_free_slots(group_id: int, monday: date, *, slot_minutes: int = 30) -> list[dict[str, Any]]:
+    """Mon–Fri 08:00–20:00 local; slot is free only if no member has a calendar overlap."""
+    members = GroupMember.query.filter_by(group_id=group_id).all()
+    if not members:
+        return []
+    user_ids = [m.user_id for m in members]
+    n = len(user_ids)
+    slot = timedelta(minutes=slot_minutes)
+    day_names = ["Mon", "Tue", "Wed", "Thu", "Fri"]
+    merged: list[dict[str, Any]] = []
+
+    for wd in range(5):
+        d = monday + timedelta(days=wd)
+        day_start = datetime.combine(d, time(8, 0))
+        day_end = datetime.combine(d, time(20, 0))
+        t = day_start
+        while t + slot <= day_end:
+            slot_end = t + slot
+            busy_any = False
+            for uid in user_ids:
+                if _slot_busy_for_user(uid, t, slot_end):
+                    busy_any = True
+                    break
+            if not busy_any:
+                if merged and merged[-1]["end"] == t.isoformat(timespec="minutes"):
+                    merged[-1]["end"] = slot_end.isoformat(timespec="minutes")
+                else:
+                    merged.append(
+                        {
+                            "day": day_names[wd],
+                            "date": d.isoformat(),
+                            "start": t.isoformat(timespec="minutes"),
+                            "end": slot_end.isoformat(timespec="minutes"),
+                            "member_count": n,
+                        }
+                    )
+            t = slot_end
+
+    return merged
+
+
+def _parse_iso_minutes(raw: str) -> datetime:
+    return datetime.fromisoformat(raw.replace("Z", "+00:00"))
+
+
+def interval_covered_by_free_slots(
+    slots: list[dict[str, Any]], start: datetime, end: datetime
+) -> bool:
+    """True if [start, end) lies inside the union of merged free intervals (same logic as common_free_slots output)."""
+    if start >= end:
+        return False
+    for s in slots:
+        s0 = _parse_iso_minutes(s["start"])
+        s1 = _parse_iso_minutes(s["end"])
+        if s0 <= start and s1 >= end:
+            return True
+    return False
+
+
+def book_free_slot_for_user(
+    *,
+    user_id: int,
+    group_id: int,
+    start: datetime,
+    end: datetime,
+    title: str = "Group study (booked)",
+) -> tuple[CalendarEvent | None, str | None]:
+    """
+    If [start, end) is a subset of a common free slot for the group and the user has no overlap, persist one event.
+
+    Returns (event, None) on success, or (None, error_code) where error_code is
+    'not_member' | 'bad_time' | 'not_free' | 'conflict'.
+    """
+    member = GroupMember.query.filter_by(group_id=group_id, user_id=user_id).first()
+    if member is None:
+        return None, "not_member"
+
+    if start >= end:
+        return None, "bad_time"
+
+    monday = monday_of(start.date())
+    free = common_free_slots(group_id, monday)
+    if not interval_covered_by_free_slots(free, start, end):
+        return None, "not_free"
+
+    if _slot_busy_for_user(user_id, start, end):
+        return None, "conflict"
+
+    ev = CalendarEvent(
+        user_id=user_id,
+        title=title,
+        event_type="group_study",
+        start_at=start,
+        end_at=end,
+        notes=f"Booked from group {group_id}",
+    )
+    db.session.add(ev)
+    db.session.commit()
+    return ev, None

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+pythonpath = .
+testpaths = tests

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,7 @@
+Flask>=3.0,<4
+Flask-Login>=0.6.3
+Flask-SQLAlchemy>=3.1,<4
+Flask-WTF>=1.2,<2
+SQLAlchemy>=2.0,<3
+Werkzeug>=3.0,<4
+pytest>=8.0,<9

--- a/run.py
+++ b/run.py
@@ -1,0 +1,6 @@
+from app import create_app
+
+app = create_app()
+
+if __name__ == "__main__":
+    app.run(host="127.0.0.1", port=5000, debug=True)

--- a/templates/group_book.html
+++ b/templates/group_book.html
@@ -1,0 +1,117 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8"/>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+  <meta name="csrf-token" content="{{ csrf_token() }}"/>
+  <title>{% if group %}{{ group.name }}{% else %}Group{% endif %} — Book free slot</title>
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet"/>
+</head>
+<body class="bg-dark text-light">
+  <nav class="navbar navbar-dark border-bottom border-secondary mb-4">
+    <div class="container-fluid">
+      <span class="navbar-brand mb-0 h1">AgileWebDevLab</span>
+      <form method="post" action="{{ url_for('auth.logout_post') }}" class="d-inline">
+        <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
+        <button type="submit" class="btn btn-outline-light btn-sm">Log out</button>
+      </form>
+    </div>
+  </nav>
+
+  <div class="container pb-5">
+    {% if not group %}
+      <div class="alert alert-warning">Group not found or you are not a member.</div>
+    {% else %}
+      <h2 class="h4 mb-1">{{ group.name }}</h2>
+      <p class="text-secondary small mb-4">Join code: <code>{{ group.join_code }}</code> — Issue #1: book a common free slot; it is saved as <strong>your</strong> calendar event (<code>event_type=group_study</code>).</p>
+
+      <div class="row g-4">
+        <div class="col-lg-6">
+          <div class="card bg-secondary bg-opacity-25 border-secondary">
+            <div class="card-header border-secondary">Common free slots (this week)</div>
+            <div class="card-body">
+              <p class="small text-secondary mb-2" id="weekLabel"></p>
+              <div id="slotList" class="d-flex flex-column gap-2"></div>
+              <p id="slotError" class="text-danger small d-none mb-0"></p>
+            </div>
+          </div>
+        </div>
+        <div class="col-lg-6">
+          <div class="card bg-secondary bg-opacity-25 border-secondary">
+            <div class="card-header border-secondary">Last booking result</div>
+            <div class="card-body">
+              <pre id="result" class="small text-info mb-0" style="white-space: pre-wrap;">—</pre>
+            </div>
+          </div>
+        </div>
+      </div>
+    {% endif %}
+  </div>
+
+  {% if group %}
+  <script src="https://code.jquery.com/jquery-3.7.1.min.js" integrity="sha256-/JqT3SQfawRcv/BIHPThkBvs0OEvtFFmqPF/lYI/Cxo=" crossorigin="anonymous"></script>
+  <script>
+    (function () {
+      const GROUP_ID = {{ group_id|tojson }};
+      const weekStart = {{ week_start_iso|tojson }};
+      $("#weekLabel").text("week_start=" + weekStart);
+
+      $.ajaxSetup({
+        beforeSend: function (xhr, settings) {
+          if (!/^(GET|HEAD|OPTIONS|TRACE)$/i.test(settings.type)) {
+            xhr.setRequestHeader("X-CSRFToken", $('meta[name="csrf-token"]').attr("content"));
+          }
+        }
+      });
+
+      function loadSlots() {
+        $("#slotError").addClass("d-none").text("");
+        $.getJSON("/api/groups/" + GROUP_ID + "/free-slots", { week_start: weekStart })
+          .done(function (data) {
+            const $list = $("#slotList").empty();
+            const slots = data.slots || [];
+            if (!slots.length) {
+              $list.append("<span class='text-secondary'>No common free slots for this week (try another account or adjust seed data).</span>");
+              return;
+            }
+            slots.forEach(function (s) {
+              const label = s.day + " " + s.start.slice(11, 16) + "–" + s.end.slice(11, 16);
+              const $btn = $("<button type='button' class='btn btn-success btn-sm'>Book</button>");
+              $btn.on("click", function () {
+                $btn.prop("disabled", true);
+                $.ajax({
+                  url: "/api/groups/" + GROUP_ID + "/book-free-slot",
+                  method: "POST",
+                  contentType: "application/json",
+                  data: JSON.stringify({ start: s.start, end: s.end })
+                })
+                  .done(function (res) {
+                    $("#result").text(JSON.stringify(res, null, 2));
+                  })
+                  .fail(function (xhr) {
+                    const msg = (xhr.responseJSON && xhr.responseJSON.error) || xhr.statusText;
+                    $("#result").text("Error: " + msg);
+                  })
+                  .always(function () {
+                    $btn.prop("disabled", false);
+                    loadSlots();
+                  });
+              });
+              $list.append(
+                $("<div class='d-flex align-items-center justify-content-between border border-secondary rounded px-3 py-2'></div>")
+                  .append($("<span></span>").text(label))
+                  .append($btn)
+              );
+            });
+          })
+          .fail(function (xhr) {
+            const msg = (xhr.responseJSON && xhr.responseJSON.error) || xhr.statusText;
+            $("#slotError").removeClass("d-none").text(msg);
+          });
+      }
+      loadSlots();
+    })();
+  </script>
+  {% endif %}
+</body>
+</html>

--- a/templates/login.html
+++ b/templates/login.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8"/>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+  <title>Sign in — AgileWebDevLab</title>
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet"/>
+</head>
+<body class="bg-light">
+  <div class="container py-5" style="max-width: 420px;">
+    <h1 class="h4 mb-4">AgileWebDevLab — demo login</h1>
+    {% with messages = get_flashed_messages(with_categories=true) %}
+      {% if messages %}
+        {% for category, message in messages %}
+          <div class="alert alert-{{ category }}">{{ message }}</div>
+        {% endfor %}
+      {% endif %}
+    {% endwith %}
+    <form method="post" action="{{ url_for('auth.login_post') }}" class="card shadow-sm p-4">
+      <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
+      <div class="mb-3">
+        <label class="form-label" for="email">Email</label>
+        <input class="form-control" id="email" name="email" type="email" required
+               placeholder="alice@lab.local" autocomplete="username"/>
+      </div>
+      <div class="mb-3">
+        <label class="form-label" for="password">Password</label>
+        <input class="form-control" id="password" name="password" type="password" required
+               placeholder="labdemo123" autocomplete="current-password"/>
+      </div>
+      <button type="submit" class="btn btn-primary w-100">Sign in</button>
+    </form>
+    <p class="text-muted small mt-3 mb-0">Seeded users: <code>alice@lab.local</code> / <code>bob@lab.local</code> — password <code>labdemo123</code>.</p>
+  </div>
+</body>
+</html>

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from app import create_app
+from app.config import Config
+
+
+class TestConfig(Config):
+    TESTING = True
+    WTF_CSRF_ENABLED = False
+
+
+@pytest.fixture()
+def app(tmp_path: Path):
+    class TC(TestConfig):
+        SQLALCHEMY_DATABASE_URI = "sqlite:///" + str(tmp_path / "test.db")
+
+    application = create_app(TC)
+    yield application
+
+
+@pytest.fixture()
+def client(app):
+    return app.test_client()

--- a/tests/test_group_book.py
+++ b/tests/test_group_book.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+from datetime import date, datetime, time, timedelta
+
+
+def _monday():
+    d = date.today()
+    return d - timedelta(days=d.weekday())
+
+
+def test_api_free_slots_requires_auth(client):
+    ws = _monday().isoformat()
+    rv = client.get(f"/api/groups/1/free-slots?week_start={ws}")
+    assert rv.status_code == 401
+
+
+def test_book_flow_happy_path_then_conflict(client):
+    client.post(
+        "/login",
+        data={"email": "alice@lab.local", "password": "labdemo123"},
+        follow_redirects=True,
+    )
+    ws = _monday().isoformat()
+    rv = client.get(f"/api/groups/1/free-slots?week_start={ws}")
+    assert rv.status_code == 200
+    payload = rv.get_json()
+    assert "slots" in payload
+    slots = payload["slots"]
+    assert isinstance(slots, list)
+    assert len(slots) >= 1
+    slot = slots[0]
+    book = client.post(
+        "/api/groups/1/book-free-slot",
+        json={"start": slot["start"], "end": slot["end"]},
+        headers={"Content-Type": "application/json"},
+    )
+    assert book.status_code == 201
+    ev = book.get_json()["event"]
+    assert ev["event_type"] == "group_study"
+
+    again = client.post(
+        "/api/groups/1/book-free-slot",
+        json={"start": slot["start"], "end": slot["end"]},
+        headers={"Content-Type": "application/json"},
+    )
+    assert again.status_code == 409
+
+
+def test_book_rejects_interval_outside_common_free_grid(client):
+    client.post(
+        "/login",
+        data={"email": "alice@lab.local", "password": "labdemo123"},
+        follow_redirects=True,
+    )
+    monday = _monday()
+    # Interval clearly outside Mon–Fri 08:00–20:00 free grid
+    start = datetime.combine(monday, time(6, 0))
+    end = datetime.combine(monday, time(6, 30))
+    rv = client.post(
+        "/api/groups/1/book-free-slot",
+        json={"start": start.isoformat(timespec="minutes"), "end": end.isoformat(timespec="minutes")},
+        headers={"Content-Type": "application/json"},
+    )
+    assert rv.status_code == 409
+    assert "not inside" in (rv.get_json() or {}).get("error", "").lower()


### PR DESCRIPTION
## Summary
Implements **Issue #9 ** for the graded lab repo: from a study group context, users can load **common free slots** for the current week and **book** one interval; the server persists a **`CalendarEvent`** for the **authenticated user** (`event_type=group_study`) only after validating the interval lies inside a computed common-free window and does not overlap that user’s existing events.

## What’s included
- Flask app with SQLAlchemy (SQLite under `instance/lab.db`, gitignored), Flask-Login, Flask-WTF **CSRF** (form + `X-CSRFToken` for JSON).
- `GET /api/groups/<id>/free-slots` and `POST /api/groups/<id>/book-free-slot`.
- Jinja page `/group/<id>` with Bootstrap + jQuery listing slots and calling the book API.
- **Seeded** users `alice@lab.local` / `bob@lab.local` (password `labdemo123`) and demo group `1` with calendar noise so common free slots exist.
- **README** runbook + `pytest` (3 tests: unauthenticated API, happy path + second booking rejected, interval outside free grid → 409).

## How to verify
1. `python3 -m venv .venv && source .venv/bin/activate && pip install -r requirements.txt && python run.py`
2. Open `/`, sign in as Alice or Bob, use **Book** on a listed slot; confirm JSON success and that re-booking the same window returns **409**.
3. `pytest`