### PR TITLE
fix(mock timetable): disable list view toggle and clarify grid-only UI

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,6 +12,12 @@ Before every push that touches Python code:
 pytest -v
 ```
 
+If you changed templates, auth, or navigation, also run **Selenium** locally when Chrome is available:
+
+```bash
+pytest tests/selenium -v
+```
+
 ## Git and GitHub hygiene
 
 1. **Configure Git identity** (must match how you want commits attributed on GitHub):

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,45 @@
+# Contributing to AgileWebDevLab
+
+This guide is for **group members and reviewers** working in this repository for Agile Web Development checkpoints and submission.
+
+## Local setup
+
+Use the same steps as **README.md** under **section 3 (How to launch the application)** (virtual environment + `pip install -r requirements.txt` + `python run.py`).
+
+Before every push that touches Python code:
+
+```bash
+pytest -v
+```
+
+## Git and GitHub hygiene
+
+1. **Configure Git identity** (must match how you want commits attributed on GitHub):
+
+   ```bash
+   git config user.name "Your Name"
+   git config user.email "you@example.com"
+   ```
+
+2. **Branch names:** prefer short prefixes, e.g. `feat/…`, `fix/…`, `docs/…`.
+
+3. **Commits:** imperative subject line, ~72 characters or less; body optional but explain *why* when the diff is not obvious.
+
+4. **Pull requests:** link the **issue** you close or continue; describe scope, how to test, and any DB reset (`instance/lab.db`) the reviewer must perform.
+
+5. **Do not commit** `instance/`, `.venv/`, `.env`, or local IDE junk (see `.gitignore`).
+
+## Code expectations
+
+- Match existing patterns: **Flask blueprints**, **SQLAlchemy** models, **JSON + CSRF** for mutating APIs used from jQuery.
+- Keep changes **scoped** to the issue; avoid unrelated refactors in the same PR.
+- If you add a new dependency, pin a sensible range in `requirements.txt` and mention it in the PR.
+
+## Documentation
+
+- **README.md** is the rubric-facing runbook (purpose, members table, launch, tests). Update it when behaviour or commands change.
+- **This file** is for workflow and review expectations.
+
+## Questions
+
+Use your unit’s preferred channel (LMS forum, lab, or GitHub Discussions if enabled). For grading-related requirements, treat the official unit outline and rubric as authoritative.

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ A **minimal Flask + SQLAlchemy + SQLite** app (Bootstrap + jQuery on the client)
 
 1. **Study group common free time** — see merged free slots for the week and **book** a slot; the server stores a **`CalendarEvent`** for the signed-in user (`event_type=group_study`), with CSRF-protected JSON APIs.
 2. **Exam preparation resources** — each **exam session** can have **multiple structured links** (`exam_resources`: title + URL), with list/create/patch/delete JSON APIs, URL validation (`http`/`https` only), and an exam detail page to manage links.
+3. **Exam sharing** — the owner can create or revoke an unguessable **`share_token`**. Visitors open a public path of the form **`/exams/shared/…`** (no login) to see a **read-only** summary and resource links; bad or revoked tokens return the same **404** message so URLs are not enumerated.
 
 Static HTML mocks for early UI exploration remain under `mock_pages/`.
 

--- a/README.md
+++ b/README.md
@@ -124,9 +124,14 @@ python run.py
 
 ## 4. How to run the tests
 
-The repository ships **automated tests** using **pytest** (see `tests/`). There is **no** Selenium suite in this tree yet; markers who expect browser automation should see this section as the single source of truth for what is automated here.
+There are two layers:
 
-### 4.1 Full test suite
+| Layer | Location | What it checks |
+|--------|----------|----------------|
+| **Unit / API** | `tests/test_*.py` | Flask test client, isolated SQLite per `tmp_path`, CSRF **disabled** for speed. |
+| **Browser (Selenium)** | `tests/selenium/` | A **real HTTP server** in a background thread + **Chrome** driving the UI (CSRF **enabled** on that app instance). |
+
+### 4.1 Unit and API tests (default, no browser)
 
 Activate the same `.venv` as in section 3, then from the repo root:
 
@@ -134,28 +139,51 @@ Activate the same `.venv` as in section 3, then from the repo root:
 pytest
 ```
 
-Equivalent with verbosity:
+Run only non-browser tests:
 
 ```bash
-pytest -v
+pytest -m "not selenium"
 ```
 
-Configuration lives in **`pytest.ini`** (`pythonpath = .` so `from app import create_app` resolves).
-
-### 4.2 Run a subset
+Single-file examples:
 
 ```bash
 pytest tests/test_exam_share.py -v
 pytest tests/test_group_book.py -v
 ```
 
-### 4.3 How tests isolate state
+`tests/conftest.py` builds the app with **`TESTING=True`**, **`WTF_CSRF_ENABLED=False`**, and a **temporary SQLite** file so tests never touch your personal `instance/lab.db`.
 
-`tests/conftest.py` builds the app with **`TESTING=True`**, **`WTF_CSRF_ENABLED=False`**, and a **temporary SQLite file** per session so tests do not touch your personal `instance/lab.db`.
+### 4.2 Selenium end-to-end tests (live server)
+
+**Prerequisites:** Google **Chrome** or **Chromium** installed on the machine running tests. Selenium **4.6+** resolves a matching **ChromeDriver** automatically in most setups.
+
+From the repo root:
+
+```bash
+pytest tests/selenium -v
+```
+
+What is covered today:
+
+- **Happy path:** open `/login`, sign in as `alice@lab.local` / `labdemo123`, expect the **Exams** page (`<title>` contains “Exams”, heading “My exam sessions”).
+- **Auth failure:** wrong password → **danger** flash on the login page; visiting **`/exams`** afterwards redirects to **`/login`** (still unauthenticated).
+
+Optional: run the browser **visibly** (debugging):
+
+```bash
+HEADLESS=0 pytest tests/selenium -v
+```
+
+If Chrome or the driver cannot start, the affected tests **`pytest.skip`** with a short reason so headless CI without a browser can still run **`pytest -m "not selenium"`** cleanly.
+
+### 4.3 Configuration
+
+**`pytest.ini`** sets `pythonpath = .` and registers the **`selenium`** marker (see `@pytest.mark.selenium` on browser tests).
 
 ### 4.4 Expected result
 
-All collected tests should **pass** on a clean checkout after `pip install -r requirements.txt`. If anything fails, capture the traceback and open an issue with the Python version and OS.
+After `pip install -r requirements.txt`, **`pytest -m "not selenium"`** should be fully green on any machine. **`pytest tests/selenium`** should be green on a workstation with Chrome available; otherwise those tests **skip** instead of failing the job, unless you treat skips as failures in your own CI policy.
 
 ---
 
@@ -166,7 +194,8 @@ All collected tests should **pass** on a clean checkout after `pip install -r re
 | `app/` | Application package (`create_app`, models, blueprints, services) |
 | `templates/` | Jinja HTML |
 | `static/js/` | Client scripts (jQuery + CSRF header on mutating calls) |
-| `tests/` | Pytest modules |
+| `tests/` | Pytest modules (API/unit) |
+| `tests/selenium/` | Selenium E2E tests (live `werkzeug` server + Chrome) |
 | `mock_pages/` | Static HTML mocks (not served by Flask by default) |
 | `run.py` | Dev entrypoint |
 | `requirements.txt` | Python dependencies |
@@ -187,3 +216,4 @@ For branching conventions, PR checklist, and Git attribution, see **[CONTRIBUTIN
 | `Address already in use` | Another process uses port 5000. Stop it or change the port in `run.py`. |
 | Old database missing new columns | Delete `instance/lab.db` and restart once, or rely on the small SQLite `ALTER` helpers in `app/__init__.py` where present. |
 | Login always fails | Use the **seeded** emails exactly (`alice@lab.local`), password `labdemo123`. |
+| Selenium tests skip | Install **Chrome**; run with `HEADLESS=0` to see errors; ensure no corporate proxy blocks driver download. |

--- a/README.md
+++ b/README.md
@@ -2,11 +2,14 @@
 
 Repository for Agile Web Development coursework (lab submission).
 
-## Issue #1 slice: Book common free slot → calendar event
+## Application overview
 
-This branch adds a **minimal runnable Flask app** (not the full StudySync draft) that implements the group feature from **Issue #1**: members see **common free time** for the current week, and **Book** persists a `CalendarEvent` for the **logged-in user** only (`event_type=group_study`), with JSON APIs, **CSRF** on mutating requests, and **SQLAlchemy** on SQLite under `instance/lab.db` (created on first run; `instance/` is gitignored).
+A **minimal Flask + SQLAlchemy + SQLite** app (Bootstrap + jQuery on the client) demonstrating:
 
-Static UI mocks remain under `mock_pages/` for reference.
+1. **Study group common free time** — see merged free slots for the week and **book** a slot; the server stores a **`CalendarEvent`** for the signed-in user (`event_type=group_study`), with CSRF-protected JSON APIs.
+2. **Exam preparation resources** — each **exam session** can have **multiple structured links** (`exam_resources`: title + URL), with list/create/patch/delete JSON APIs, URL validation (`http`/`https` only), and an exam detail page to manage links.
+
+Static HTML mocks for early UI exploration remain under `mock_pages/`.
 
 ## Prerequisites
 
@@ -21,16 +24,16 @@ pip install -r requirements.txt
 python run.py
 ```
 
-Open **http://127.0.0.1:5000/** — you will be redirected to log in, then to **/group/1**.
+Open **http://127.0.0.1:5000/** — after sign-in you land on **Exams**. Use the navbar to open **Group** for the booking flow, or open an exam to add/remove resource links.
 
 ### Seeded demo accounts
 
-| Email            | Password   |
-|------------------|------------|
+| Email             | Password     |
+|-------------------|--------------|
 | `alice@lab.local` | `labdemo123` |
 | `bob@lab.local`   | `labdemo123` |
 
-Both users belong to **Demo Lab Group** (join code `LABDEMO1`). Seeded calendar events leave **common free slots** you can book from the UI.
+Alice has a sample **exam session** with one starter resource; both users belong to **Demo Lab Group** (join code `LABDEMO1`) with seeded calendar events so common free slots exist for booking.
 
 ## Tests
 

--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ After `pip install -r requirements.txt`, **`pytest -m "not selenium"`** should b
 | `static/js/` | Client scripts (jQuery + CSRF header on mutating calls) |
 | `tests/` | Pytest modules (API/unit) |
 | `tests/selenium/` | Selenium E2E tests (live `werkzeug` server + Chrome) |
-| `mock_pages/` | Static HTML mocks (not served by Flask by default) |
+| `mock_pages/` | Static HTML mocks (open files in a browser; not served by Flask). Timetable mock uses **grid-only**: the list-view control is **disabled** with a clear hint so it is not mistaken for a broken click target. |
 | `run.py` | Dev entrypoint |
 | `requirements.txt` | Python dependencies |
 

--- a/README.md
+++ b/README.md
@@ -1,2 +1,41 @@
 # AgileWebDevLab
-This repo is used for Agile Web Development exercises.
+
+Repository for Agile Web Development coursework (lab submission).
+
+## Issue #1 slice: Book common free slot → calendar event
+
+This branch adds a **minimal runnable Flask app** (not the full StudySync draft) that implements the group feature from **Issue #1**: members see **common free time** for the current week, and **Book** persists a `CalendarEvent` for the **logged-in user** only (`event_type=group_study`), with JSON APIs, **CSRF** on mutating requests, and **SQLAlchemy** on SQLite under `instance/lab.db` (created on first run; `instance/` is gitignored).
+
+Static UI mocks remain under `mock_pages/` for reference.
+
+## Prerequisites
+
+- Python 3.11+ (tested with 3.13)
+
+## Setup and run
+
+```bash
+python3 -m venv .venv
+source .venv/bin/activate
+pip install -r requirements.txt
+python run.py
+```
+
+Open **http://127.0.0.1:5000/** — you will be redirected to log in, then to **/group/1**.
+
+### Seeded demo accounts
+
+| Email            | Password   |
+|------------------|------------|
+| `alice@lab.local` | `labdemo123` |
+| `bob@lab.local`   | `labdemo123` |
+
+Both users belong to **Demo Lab Group** (join code `LABDEMO1`). Seeded calendar events leave **common free slots** you can book from the UI.
+
+## Tests
+
+```bash
+pytest
+```
+
+Uses a temporary SQLite file per test run (`WTF_CSRF_ENABLED=False` in the test app only).

--- a/README.md
+++ b/README.md
@@ -1,45 +1,189 @@
 # AgileWebDevLab
 
-Repository for Agile Web Development coursework (lab submission).
+Minimal **Flask** web application for Agile Web Development coursework: study-group scheduling, exam preparation resources, and optional read-only exam sharing. This document is written so a marker or new teammate can **clone the repo once** and follow **sections 3–5** without guesswork.
 
-## Application overview
+---
 
-A **minimal Flask + SQLAlchemy + SQLite** app (Bootstrap + jQuery on the client) demonstrating:
+## 1. Purpose and design
 
-1. **Study group common free time** — see merged free slots for the week and **book** a slot; the server stores a **`CalendarEvent`** for the signed-in user (`event_type=group_study`), with CSRF-protected JSON APIs.
-2. **Exam preparation resources** — each **exam session** can have **multiple structured links** (`exam_resources`: title + URL), with list/create/patch/delete JSON APIs, URL validation (`http`/`https` only), and an exam detail page to manage links.
-3. **Exam sharing** — the owner can create or revoke an unguessable **`share_token`**. Visitors open a public path of the form **`/exams/shared/…`** (no login) to see a **read-only** summary and resource links; bad or revoked tokens return the same **404** message so URLs are not enumerated.
+**Purpose:** give students a small but coherent **client–server** example: HTML templates and jQuery on the browser, JSON APIs with **CSRF** protection, **Flask-Login** sessions, and **SQLite** persistence via **SQLAlchemy**.
 
-Static HTML mocks for early UI exploration remain under `mock_pages/`.
+**Design (high level):**
 
-## Prerequisites
+| Area | Behaviour |
+|------|-----------|
+| **Study groups** | Two seeded users share a group. The server computes **common free time** for Monday–Friday and lets a member **book** a slot, persisting a personal **`CalendarEvent`** (`event_type=group_study`). |
+| **Exams** | Each user owns **exam sessions**. A session has many **`exam_resources`** (title + URL) with validation and JSON CRUD. |
+| **Sharing** | The exam owner may enable a random **`share_token`**. Visitors hit a **public read-only** URL without logging in; revoked or unknown tokens yield a generic **404** page. |
 
-- Python 3.11+ (tested with 3.13)
+**Who uses it:** demo markers and the project group for checkpoints and final submission. **Not** intended for production deployment; default `SECRET_KEY` is for local use only.
 
-## Setup and run
+---
+
+## 2. Group members
+
+Replace the placeholder rows below with your **actual** group data before final submission (UWA policy: use the identifiers your unit expects).
+
+| UWA ID | Full name | GitHub username |
+|--------|-----------|-------------------|
+| *e.g. 12345678* | *Replace with legal name* | *@github-handle* |
+| *e.g. 23456789* | *Replace* | *@github-handle* |
+| *e.g. 34567890* | *Replace* | *@github-handle* |
+
+If your group has fewer than three people, delete extra rows. If you have four, add another row.
+
+---
+
+## 3. How to launch the application
+
+### 3.1 Prerequisites
+
+- **Python 3.11+** (development verified on Python 3.13).
+- A terminal and a modern browser.
+
+### 3.2 First-time setup (virtual environment + dependencies)
+
+From the repository root:
+
+**macOS / Linux**
 
 ```bash
 python3 -m venv .venv
 source .venv/bin/activate
+python -m pip install --upgrade pip
 pip install -r requirements.txt
+```
+
+**Windows (PowerShell)**
+
+```powershell
+python -m venv .venv
+.\.venv\Scripts\Activate.ps1
+python -m pip install --upgrade pip
+pip install -r requirements.txt
+```
+
+**Windows (cmd.exe)**
+
+```cmd
+python -m venv .venv
+.venv\Scripts\activate.bat
+python -m pip install --upgrade pip
+pip install -r requirements.txt
+```
+
+### 3.3 Start the development server
+
+With the virtual environment **activated**:
+
+```bash
 python run.py
 ```
 
-Open **http://127.0.0.1:5000/** — after sign-in you land on **Exams**. Use the navbar to open **Group** for the booking flow, or open an exam to add/remove resource links.
+You should see logging similar to `Running on http://127.0.0.1:5000`.
 
-### Seeded demo accounts
+Open **http://127.0.0.1:5000/** in the browser. Unauthenticated visitors are sent to the **login** page; after sign-in you land on **Exams**.
 
-| Email             | Password     |
-|-------------------|--------------|
+### 3.4 Demo accounts (seeded on first run)
+
+| Email | Password |
+|-------|----------|
 | `alice@lab.local` | `labdemo123` |
-| `bob@lab.local`   | `labdemo123` |
+| `bob@lab.local` | `labdemo123` |
 
-Alice has a sample **exam session** with one starter resource; both users belong to **Demo Lab Group** (join code `LABDEMO1`) with seeded calendar events so common free slots exist for booking.
+Alice owns a sample exam with one starter link; both users are in **Demo Lab Group** (`LABDEMO1`) with calendar events so **Group → common free slots** is non-empty.
 
-## Tests
+### 3.5 Useful URLs (after login)
+
+| Path | Description |
+|------|-------------|
+| `/exams` | List of your exam sessions |
+| `/exams/<id>` | Exam detail: resources + share link controls |
+| `/group/1` | Group workspace for the seeded group |
+| `/exams/shared/<token>` | **Public** read-only exam (only when a share token exists) |
+
+### 3.6 Database and local files
+
+- SQLite file: **`instance/lab.db`** (created automatically; the `instance/` directory is gitignored).
+- To **reset all data** (including schema migrations applied at runtime), stop the server, delete `instance/lab.db`, and start again so seeds re-run.
+
+### 3.7 Optional configuration
+
+| Variable | Meaning |
+|----------|---------|
+| `SECRET_KEY` | Flask session signing. Set in production; defaults to an insecure dev value in code. |
+
+Example (Unix):
+
+```bash
+export SECRET_KEY="choose-a-long-random-string"
+python run.py
+```
+
+---
+
+## 4. How to run the tests
+
+The repository ships **automated tests** using **pytest** (see `tests/`). There is **no** Selenium suite in this tree yet; markers who expect browser automation should see this section as the single source of truth for what is automated here.
+
+### 4.1 Full test suite
+
+Activate the same `.venv` as in section 3, then from the repo root:
 
 ```bash
 pytest
 ```
 
-Uses a temporary SQLite file per test run (`WTF_CSRF_ENABLED=False` in the test app only).
+Equivalent with verbosity:
+
+```bash
+pytest -v
+```
+
+Configuration lives in **`pytest.ini`** (`pythonpath = .` so `from app import create_app` resolves).
+
+### 4.2 Run a subset
+
+```bash
+pytest tests/test_exam_share.py -v
+pytest tests/test_group_book.py -v
+```
+
+### 4.3 How tests isolate state
+
+`tests/conftest.py` builds the app with **`TESTING=True`**, **`WTF_CSRF_ENABLED=False`**, and a **temporary SQLite file** per session so tests do not touch your personal `instance/lab.db`.
+
+### 4.4 Expected result
+
+All collected tests should **pass** on a clean checkout after `pip install -r requirements.txt`. If anything fails, capture the traceback and open an issue with the Python version and OS.
+
+---
+
+## 5. Repository layout (quick reference)
+
+| Path | Role |
+|------|------|
+| `app/` | Application package (`create_app`, models, blueprints, services) |
+| `templates/` | Jinja HTML |
+| `static/js/` | Client scripts (jQuery + CSRF header on mutating calls) |
+| `tests/` | Pytest modules |
+| `mock_pages/` | Static HTML mocks (not served by Flask by default) |
+| `run.py` | Dev entrypoint |
+| `requirements.txt` | Python dependencies |
+
+---
+
+## 6. Contributor guide
+
+For branching conventions, PR checklist, and Git attribution, see **[CONTRIBUTING.md](CONTRIBUTING.md)**.
+
+---
+
+## 7. Troubleshooting
+
+| Problem | Things to try |
+|---------|----------------|
+| `ModuleNotFoundError: No module named 'app'` | Run `pytest` from the **repository root**, or use `pytest` (not `python -m pytest` from a wrong cwd). `pytest.ini` sets `pythonpath`. |
+| `Address already in use` | Another process uses port 5000. Stop it or change the port in `run.py`. |
+| Old database missing new columns | Delete `instance/lab.db` and restart once, or rely on the small SQLite `ALTER` helpers in `app/__init__.py` where present. |
+| Login always fails | Use the **seeded** emails exactly (`alice@lab.local`), password `labdemo123`. |

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -88,6 +88,34 @@ def _seed_exam_demo_if_empty() -> None:
     db.session.commit()
 
 
+def _migrate_exam_share_token_column() -> None:
+    """SQLite: add share_token if DB was created before this column existed."""
+    from sqlalchemy import inspect, text
+
+    try:
+        insp = inspect(db.engine)
+        cols = [c["name"] for c in insp.get_columns("exam_sessions")]
+    except Exception:
+        return
+    if "share_token" in cols:
+        return
+    try:
+        with db.engine.begin() as conn:
+            conn.execute(text("ALTER TABLE exam_sessions ADD COLUMN share_token VARCHAR(64)"))
+    except Exception:
+        return
+    try:
+        with db.engine.begin() as conn:
+            conn.execute(
+                text(
+                    "CREATE UNIQUE INDEX IF NOT EXISTS uq_exam_sessions_share_token "
+                    "ON exam_sessions (share_token)"
+                )
+            )
+    except Exception:
+        pass
+
+
 def create_app(config_object: type = Config) -> Flask:
     root = Path(__file__).resolve().parent.parent
     os.makedirs(root / "instance", exist_ok=True)
@@ -131,6 +159,7 @@ def create_app(config_object: type = Config) -> Flask:
 
     with app.app_context():
         db.create_all()
+        _migrate_exam_share_token_column()
         _seed_demo_data()
         _seed_exam_demo_if_empty()
 

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,0 +1,102 @@
+from __future__ import annotations
+
+import os
+from datetime import date, datetime, time, timedelta
+from pathlib import Path
+
+from flask import Flask, redirect, url_for
+
+from app.config import Config
+from app.extensions import csrf, db, login_manager
+
+
+def _seed_demo_data() -> None:
+    from app.models import CalendarEvent, GroupMember, StudyGroup, User
+
+    if User.query.filter_by(email="alice@lab.local").first() is not None:
+        return
+
+    alice = User(email="alice@lab.local", full_name="Alice Lab")
+    alice.set_password("labdemo123")
+    bob = User(email="bob@lab.local", full_name="Bob Lab")
+    bob.set_password("labdemo123")
+    db.session.add_all([alice, bob])
+    db.session.flush()
+
+    g = StudyGroup(name="Demo Lab Group", join_code="LABDEMO1", created_by_user_id=alice.id)
+    db.session.add(g)
+    db.session.flush()
+    db.session.add_all(
+        [
+            GroupMember(group_id=g.id, user_id=alice.id, role="owner"),
+            GroupMember(group_id=g.id, user_id=bob.id, role="member"),
+        ]
+    )
+
+    monday = date.today() - timedelta(days=date.today().weekday())
+    # Bob busy Mon 10:00–12:00; Alice busy Mon 14:00–16:00 → common free includes Mon 12:00–14:00 etc.
+    db.session.add(
+        CalendarEvent(
+            user_id=bob.id,
+            title="Lecture (seed)",
+            event_type="class",
+            start_at=datetime.combine(monday, time(10, 0)),
+            end_at=datetime.combine(monday, time(12, 0)),
+        )
+    )
+    db.session.add(
+        CalendarEvent(
+            user_id=alice.id,
+            title="Tutorial (seed)",
+            event_type="class",
+            start_at=datetime.combine(monday, time(14, 0)),
+            end_at=datetime.combine(monday, time(16, 0)),
+        )
+    )
+    db.session.commit()
+
+
+def create_app(config_object: type = Config) -> Flask:
+    root = Path(__file__).resolve().parent.parent
+    os.makedirs(root / "instance", exist_ok=True)
+
+    app = Flask(
+        __name__,
+        instance_relative_config=False,
+        template_folder=str(root / "templates"),
+        static_folder=str(root / "static"),
+    )
+    app.config.from_object(config_object)
+
+    db.init_app(app)
+    login_manager.init_app(app)
+    csrf.init_app(app)
+    login_manager.login_view = "auth.login_page"
+
+    from flask import jsonify, request
+
+    @login_manager.unauthorized_handler
+    def _unauthorized():
+        if request.path.startswith("/api/"):
+            return jsonify({"error": "Unauthorized"}), 401
+        from flask import redirect, url_for
+
+        return redirect(url_for("auth.login_page", next=request.url))
+
+    from app import models  # noqa: F401
+
+    from app.blueprints.auth import bp as auth_bp
+    from app.blueprints.group_book import bp as group_book_bp
+
+    app.register_blueprint(auth_bp)
+    app.register_blueprint(group_book_bp)
+
+    @app.get("/")
+    def index():
+        return redirect(url_for("group_book.group_page", group_id=1))
+
+    with app.app_context():
+        db.create_all()
+        _seed_demo_data()
+
+    return app

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -56,6 +56,38 @@ def _seed_demo_data() -> None:
     db.session.commit()
 
 
+def _seed_exam_demo_if_empty() -> None:
+    from app.models import ExamResource, ExamSession, User
+
+    alice = User.query.filter_by(email="alice@lab.local").first()
+    if alice is None:
+        return
+    if ExamSession.query.filter_by(user_id=alice.id).first() is not None:
+        return
+    monday = date.today() - timedelta(days=date.today().weekday())
+    start = datetime.combine(monday + timedelta(days=10), time(9, 0))
+    end = start + timedelta(hours=2)
+    ex = ExamSession(
+        user_id=alice.id,
+        title="Practice exam (seed)",
+        course_code="LAB",
+        starts_at=start,
+        ends_at=end,
+        notes="Add preparation resources on the exam detail page.",
+    )
+    db.session.add(ex)
+    db.session.flush()
+    db.session.add(
+        ExamResource(
+            exam_id=ex.id,
+            title="Example reading (replace me)",
+            url="https://www.w3.org/",
+            sort_order=0,
+        )
+    )
+    db.session.commit()
+
+
 def create_app(config_object: type = Config) -> Flask:
     root = Path(__file__).resolve().parent.parent
     os.makedirs(root / "instance", exist_ok=True)
@@ -86,17 +118,20 @@ def create_app(config_object: type = Config) -> Flask:
     from app import models  # noqa: F401
 
     from app.blueprints.auth import bp as auth_bp
+    from app.blueprints.exams import bp as exams_bp
     from app.blueprints.group_book import bp as group_book_bp
 
     app.register_blueprint(auth_bp)
+    app.register_blueprint(exams_bp)
     app.register_blueprint(group_book_bp)
 
     @app.get("/")
     def index():
-        return redirect(url_for("group_book.group_page", group_id=1))
+        return redirect(url_for("exams.exams_list"))
 
     with app.app_context():
         db.create_all()
         _seed_demo_data()
+        _seed_exam_demo_if_empty()
 
     return app

--- a/app/blueprints/auth.py
+++ b/app/blueprints/auth.py
@@ -25,7 +25,7 @@ def login_post():
         flash("Invalid email or password.", "danger")
         return redirect(url_for("auth.login_page"))
     login_user(user, remember=True)
-    nxt = request.args.get("next") or url_for("group_book.group_page", group_id=1)
+    nxt = request.args.get("next") or url_for("exams.exams_list")
     return redirect(nxt)
 
 

--- a/app/blueprints/auth.py
+++ b/app/blueprints/auth.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+from flask import Blueprint, flash, redirect, render_template, request, url_for
+from flask_login import login_required, login_user, logout_user
+
+from app.extensions import db
+from app.models import User
+
+bp = Blueprint("auth", __name__)
+
+
+@bp.get("/login")
+def login_page():
+    if request.args.get("next"):
+        pass
+    return render_template("login.html")
+
+
+@bp.post("/login")
+def login_post():
+    email = (request.form.get("email") or "").strip().lower()
+    password = request.form.get("password") or ""
+    user = User.query.filter_by(email=email).first()
+    if user is None or not user.check_password(password):
+        flash("Invalid email or password.", "danger")
+        return redirect(url_for("auth.login_page"))
+    login_user(user, remember=True)
+    nxt = request.args.get("next") or url_for("group_book.group_page", group_id=1)
+    return redirect(nxt)
+
+
+@bp.post("/logout")
+@login_required
+def logout_post():
+    logout_user()
+    return redirect(url_for("auth.login_page"))

--- a/app/blueprints/exams.py
+++ b/app/blueprints/exams.py
@@ -1,0 +1,140 @@
+from __future__ import annotations
+
+from urllib.parse import urlparse
+
+from flask import Blueprint, jsonify, render_template, request
+from sqlalchemy import func
+from flask_login import current_user, login_required
+
+from app.extensions import db
+from app.models import ExamResource, ExamSession
+
+bp = Blueprint("exams", __name__)
+
+MAX_TITLE = 200
+MAX_URL = 2048
+
+
+def _exam_owned(exam_id: int) -> ExamSession | None:
+    ex = db.session.get(ExamSession, exam_id)
+    if ex is None or ex.user_id != current_user.id:
+        return None
+    return ex
+
+
+def _valid_public_url(url: str) -> bool:
+    p = urlparse(url.strip())
+    return p.scheme in ("http", "https") and bool(p.netloc)
+
+
+@bp.get("/exams")
+@login_required
+def exams_list():
+    rows = (
+        ExamSession.query.filter_by(user_id=current_user.id)
+        .order_by(ExamSession.starts_at.asc())
+        .all()
+    )
+    return render_template("exams_list.html", exams=rows)
+
+
+@bp.get("/exams/<int:exam_id>")
+@login_required
+def exam_detail(exam_id: int):
+    ex = _exam_owned(exam_id)
+    if ex is None:
+        return render_template("exam_detail.html", exam=None, exam_id=exam_id), 404
+    resources = ex.resources.order_by(ExamResource.sort_order.asc(), ExamResource.id.asc()).all()
+    return render_template("exam_detail.html", exam=ex, exam_id=exam_id, resources=resources)
+
+
+@bp.get("/api/exams/<int:exam_id>/resources")
+@login_required
+def api_list_resources(exam_id: int):
+    ex = _exam_owned(exam_id)
+    if ex is None:
+        return jsonify({"error": "Not found."}), 404
+    rows = ex.resources.order_by(ExamResource.sort_order.asc(), ExamResource.id.asc()).all()
+    return jsonify({"resources": [r.to_dict() for r in rows]})
+
+
+@bp.post("/api/exams/<int:exam_id>/resources")
+@login_required
+def api_create_resource(exam_id: int):
+    ex = _exam_owned(exam_id)
+    if ex is None:
+        return jsonify({"error": "Not found."}), 404
+    if not request.is_json:
+        return jsonify({"error": "Expected application/json"}), 400
+    data = request.get_json(silent=True) or {}
+    title = (data.get("title") or "").strip()
+    url = (data.get("url") or "").strip()
+    if not title:
+        return jsonify({"error": "title is required."}), 400
+    if len(title) > MAX_TITLE:
+        return jsonify({"error": "title is too long."}), 400
+    if not url:
+        return jsonify({"error": "url is required."}), 400
+    if len(url) > MAX_URL:
+        return jsonify({"error": "url is too long."}), 400
+    if not _valid_public_url(url):
+        return jsonify({"error": "url must be an http or https URL with a host."}), 400
+
+    mx = db.session.query(func.max(ExamResource.sort_order)).filter_by(exam_id=exam_id).scalar()
+    next_order = (mx if mx is not None else -1) + 1
+
+    r = ExamResource(exam_id=exam_id, title=title, url=url, sort_order=next_order)
+    db.session.add(r)
+    db.session.commit()
+    return jsonify({"resource": r.to_dict()}), 201
+
+
+@bp.patch("/api/exams/<int:exam_id>/resources/<int:resource_id>")
+@login_required
+def api_patch_resource(exam_id: int, resource_id: int):
+    ex = _exam_owned(exam_id)
+    if ex is None:
+        return jsonify({"error": "Not found."}), 404
+    r = db.session.get(ExamResource, resource_id)
+    if r is None or r.exam_id != exam_id:
+        return jsonify({"error": "Not found."}), 404
+    if not request.is_json:
+        return jsonify({"error": "Expected application/json"}), 400
+    data = request.get_json(silent=True) or {}
+    if "title" in data:
+        t = (data.get("title") or "").strip()
+        if not t:
+            return jsonify({"error": "title cannot be empty."}), 400
+        if len(t) > MAX_TITLE:
+            return jsonify({"error": "title is too long."}), 400
+        r.title = t
+    if "url" in data:
+        u = (data.get("url") or "").strip()
+        if not u:
+            return jsonify({"error": "url cannot be empty."}), 400
+        if len(u) > MAX_URL:
+            return jsonify({"error": "url is too long."}), 400
+        if not _valid_public_url(u):
+            return jsonify({"error": "url must be an http or https URL with a host."}), 400
+        r.url = u
+    if "sort_order" in data:
+        try:
+            r.sort_order = int(data["sort_order"])
+        except (TypeError, ValueError):
+            return jsonify({"error": "sort_order must be an integer."}), 400
+    db.session.commit()
+    return jsonify({"resource": r.to_dict()})
+
+
+@bp.delete("/api/exams/<int:exam_id>/resources/<int:resource_id>")
+@login_required
+def api_delete_resource(exam_id: int, resource_id: int):
+    ex = _exam_owned(exam_id)
+    if ex is None:
+        return jsonify({"error": "Not found."}), 404
+    r = db.session.get(ExamResource, resource_id)
+    if r is None or r.exam_id != exam_id:
+        return jsonify({"error": "Not found."}), 404
+    db.session.delete(r)
+    db.session.commit()
+    return "", 204

--- a/app/blueprints/exams.py
+++ b/app/blueprints/exams.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
+import secrets
 from urllib.parse import urlparse
 
-from flask import Blueprint, jsonify, render_template, request
+from flask import Blueprint, jsonify, render_template, request, url_for
 from sqlalchemy import func
 from flask_login import current_user, login_required
 
@@ -13,6 +14,7 @@ bp = Blueprint("exams", __name__)
 
 MAX_TITLE = 200
 MAX_URL = 2048
+TOKEN_NBYTES = 32
 
 
 def _exam_owned(exam_id: int) -> ExamSession | None:
@@ -22,9 +24,43 @@ def _exam_owned(exam_id: int) -> ExamSession | None:
     return ex
 
 
+def _share_url_for_token(token: str) -> str:
+    root = (request.url_root or "/").rstrip("/")
+    return root + url_for("exams.exam_shared_public", token=token)
+
+
+def _exam_by_share_token(token: str | None) -> ExamSession | None:
+    if not token or len(token) > 72:
+        return None
+    return ExamSession.query.filter_by(share_token=token.strip()).first()
+
+
 def _valid_public_url(url: str) -> bool:
     p = urlparse(url.strip())
     return p.scheme in ("http", "https") and bool(p.netloc)
+
+
+@bp.get("/exams/shared/<string:token>")
+def exam_shared_public(token: str):
+    """Read-only exam summary for holders of an active share token (no login)."""
+    ex = _exam_by_share_token(token)
+    if ex is None:
+        return (
+            render_template(
+                "exam_shared_public.html",
+                ok=False,
+                exam=None,
+                resources=[],
+            ),
+            404,
+        )
+    rows = ex.resources.order_by(ExamResource.sort_order.asc(), ExamResource.id.asc()).all()
+    return render_template(
+        "exam_shared_public.html",
+        ok=True,
+        exam=ex,
+        resources=[{"title": r.title, "url": r.url} for r in rows],
+    )
 
 
 @bp.get("/exams")
@@ -45,7 +81,44 @@ def exam_detail(exam_id: int):
     if ex is None:
         return render_template("exam_detail.html", exam=None, exam_id=exam_id), 404
     resources = ex.resources.order_by(ExamResource.sort_order.asc(), ExamResource.id.asc()).all()
-    return render_template("exam_detail.html", exam=ex, exam_id=exam_id, resources=resources)
+    share_url = None
+    if ex.share_token:
+        share_url = _share_url_for_token(ex.share_token)
+    return render_template(
+        "exam_detail.html",
+        exam=ex,
+        exam_id=exam_id,
+        resources=resources,
+        share_url=share_url,
+    )
+
+
+@bp.post("/api/exams/<int:exam_id>/share-token")
+@login_required
+def api_create_or_rotate_share_token(exam_id: int):
+    """Create or replace the share token with a new cryptographically random value."""
+    ex = _exam_owned(exam_id)
+    if ex is None:
+        return jsonify({"error": "Not found."}), 404
+    ex.share_token = secrets.token_urlsafe(TOKEN_NBYTES)
+    db.session.commit()
+    return jsonify(
+        {
+            "share_token": ex.share_token,
+            "share_url": _share_url_for_token(ex.share_token),
+        }
+    ), 201
+
+
+@bp.delete("/api/exams/<int:exam_id>/share-token")
+@login_required
+def api_revoke_share_token(exam_id: int):
+    ex = _exam_owned(exam_id)
+    if ex is None:
+        return jsonify({"error": "Not found."}), 404
+    ex.share_token = None
+    db.session.commit()
+    return "", 204
 
 
 @bp.get("/api/exams/<int:exam_id>/resources")

--- a/app/blueprints/group_book.py
+++ b/app/blueprints/group_book.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+from datetime import date, datetime
+
+from flask import Blueprint, jsonify, render_template, request
+from flask_login import current_user, login_required
+
+from app.extensions import db
+from app.models import GroupMember, StudyGroup
+from app.services.group_schedule import book_free_slot_for_user, common_free_slots, monday_of
+
+bp = Blueprint("group_book", __name__)
+
+
+def _parse_week_start(raw: str | None):
+    if not raw:
+        return None
+    try:
+        from datetime import date
+
+        d = date.fromisoformat(raw)
+    except ValueError:
+        return None
+    return monday_of(d)
+
+
+def _group_if_member(group_id: int) -> StudyGroup | None:
+    g = db.session.get(StudyGroup, group_id)
+    if g is None:
+        return None
+    if GroupMember.query.filter_by(group_id=group_id, user_id=current_user.id).first() is None:
+        return None
+    return g
+
+
+@bp.get("/group/<int:group_id>")
+@login_required
+def group_page(group_id: int):
+    if _group_if_member(group_id) is None:
+        return render_template("group_book.html", group=None, group_id=group_id), 404
+    g = db.session.get(StudyGroup, group_id)
+    week_start_iso = monday_of(date.today()).isoformat()
+    return render_template(
+        "group_book.html", group=g, group_id=group_id, week_start_iso=week_start_iso
+    )
+
+
+@bp.get("/api/groups/<int:group_id>/free-slots")
+@login_required
+def api_free_slots(group_id: int):
+    if _group_if_member(group_id) is None:
+        return jsonify({"error": "Not found."}), 404
+    ws = _parse_week_start(request.args.get("week_start"))
+    if ws is None:
+        return jsonify({"error": "Invalid or missing week_start (YYYY-MM-DD)."}), 400
+    slots = common_free_slots(group_id, ws)
+    return jsonify({"week_start": ws.isoformat(), "slots": slots})
+
+
+@bp.post("/api/groups/<int:group_id>/book-free-slot")
+@login_required
+def api_book_free_slot(group_id: int):
+    if _group_if_member(group_id) is None:
+        return jsonify({"error": "Not found."}), 404
+    if not request.is_json:
+        return jsonify({"error": "Expected application/json"}), 400
+    data = request.get_json(silent=True) or {}
+    start_raw = data.get("start")
+    end_raw = data.get("end")
+    if not start_raw or not end_raw:
+        return jsonify({"error": "start and end ISO datetimes are required."}), 400
+    try:
+        start = datetime.fromisoformat(str(start_raw).replace("Z", "+00:00"))
+        end = datetime.fromisoformat(str(end_raw).replace("Z", "+00:00"))
+    except ValueError:
+        return jsonify({"error": "Invalid start or end datetime."}), 400
+
+    ev, err = book_free_slot_for_user(user_id=current_user.id, group_id=group_id, start=start, end=end)
+    if err == "not_member":
+        return jsonify({"error": "Not found."}), 404
+    if err == "bad_time":
+        return jsonify({"error": "end must be after start."}), 400
+    if err == "not_free":
+        return jsonify({"error": "That interval is not inside a common free slot for this week."}), 409
+    if err == "conflict":
+        return jsonify({"error": "You already have an event overlapping that time."}), 409
+    assert ev is not None
+    return jsonify({"event": ev.to_dict()}), 201

--- a/app/config.py
+++ b/app/config.py
@@ -1,0 +1,11 @@
+import os
+from pathlib import Path
+
+
+class Config:
+    SECRET_KEY = os.environ.get("SECRET_KEY", "dev-lab-only-change-in-production")
+    SQLALCHEMY_DATABASE_URI = "sqlite:///" + str(
+        Path(__file__).resolve().parent.parent / "instance" / "lab.db"
+    )
+    SQLALCHEMY_TRACK_MODIFICATIONS = False
+    WTF_CSRF_HEADERS = ["X-CSRFToken", "X-CSRF-Token"]

--- a/app/extensions.py
+++ b/app/extensions.py
@@ -1,0 +1,7 @@
+from flask_login import LoginManager
+from flask_sqlalchemy import SQLAlchemy
+from flask_wtf.csrf import CSRFProtect
+
+db = SQLAlchemy()
+login_manager = LoginManager()
+csrf = CSRFProtect()

--- a/app/models.py
+++ b/app/models.py
@@ -25,6 +25,12 @@ class User(UserMixin, db.Model):
         lazy="dynamic",
         cascade="all, delete-orphan",
     )
+    exam_sessions = db.relationship(
+        "ExamSession",
+        backref="user",
+        lazy="dynamic",
+        cascade="all, delete-orphan",
+    )
 
     def set_password(self, password: str) -> None:
         from werkzeug.security import generate_password_hash
@@ -96,6 +102,56 @@ class GroupMember(db.Model):
     role = db.Column(db.String(20), nullable=False, default="member")
 
     group = db.relationship("StudyGroup", back_populates="members")
+
+
+class ExamSession(db.Model):
+    __tablename__ = "exam_sessions"
+
+    id = db.Column(db.Integer, primary_key=True)
+    user_id = db.Column(db.Integer, db.ForeignKey("users.id"), nullable=False, index=True)
+    title = db.Column(db.String(200), nullable=False)
+    course_code = db.Column(db.String(32), nullable=True)
+    starts_at = db.Column(db.DateTime, nullable=False, index=True)
+    ends_at = db.Column(db.DateTime, nullable=False)
+    notes = db.Column(db.Text, nullable=True)
+
+    resources = db.relationship(
+        "ExamResource",
+        backref="exam",
+        lazy="dynamic",
+        cascade="all, delete-orphan",
+        order_by="ExamResource.sort_order",
+    )
+
+    def to_dict(self) -> dict:
+        return {
+            "id": self.id,
+            "title": self.title,
+            "course_code": self.course_code or "",
+            "starts_at": self.starts_at.isoformat(timespec="minutes"),
+            "ends_at": self.ends_at.isoformat(timespec="minutes"),
+            "notes": self.notes or "",
+        }
+
+
+class ExamResource(db.Model):
+    __tablename__ = "exam_resources"
+
+    id = db.Column(db.Integer, primary_key=True)
+    exam_id = db.Column(db.Integer, db.ForeignKey("exam_sessions.id"), nullable=False, index=True)
+    title = db.Column(db.String(200), nullable=False)
+    url = db.Column(db.String(2048), nullable=False)
+    sort_order = db.Column(db.Integer, nullable=False, default=0)
+    created_at = db.Column(db.DateTime, server_default=db.func.now(), nullable=False)
+
+    def to_dict(self) -> dict:
+        return {
+            "id": self.id,
+            "exam_id": self.exam_id,
+            "title": self.title,
+            "url": self.url,
+            "sort_order": self.sort_order,
+        }
 
 
 @login_manager.user_loader

--- a/app/models.py
+++ b/app/models.py
@@ -114,6 +114,7 @@ class ExamSession(db.Model):
     starts_at = db.Column(db.DateTime, nullable=False, index=True)
     ends_at = db.Column(db.DateTime, nullable=False)
     notes = db.Column(db.Text, nullable=True)
+    share_token = db.Column(db.String(64), nullable=True, unique=True, index=True)
 
     resources = db.relationship(
         "ExamResource",

--- a/app/models.py
+++ b/app/models.py
@@ -1,0 +1,105 @@
+from __future__ import annotations
+
+from flask_login import UserMixin
+
+from app.extensions import db, login_manager
+
+
+class User(UserMixin, db.Model):
+    __tablename__ = "users"
+
+    id = db.Column(db.Integer, primary_key=True)
+    email = db.Column(db.String(255), unique=True, nullable=False, index=True)
+    password_hash = db.Column(db.String(256), nullable=False)
+    full_name = db.Column(db.String(120), nullable=False)
+
+    calendar_events = db.relationship(
+        "CalendarEvent",
+        backref="user",
+        lazy="dynamic",
+        cascade="all, delete-orphan",
+    )
+    group_memberships = db.relationship(
+        "GroupMember",
+        backref="user",
+        lazy="dynamic",
+        cascade="all, delete-orphan",
+    )
+
+    def set_password(self, password: str) -> None:
+        from werkzeug.security import generate_password_hash
+
+        self.password_hash = generate_password_hash(password)
+
+    def check_password(self, password: str) -> bool:
+        from werkzeug.security import check_password_hash
+
+        return check_password_hash(self.password_hash, password)
+
+
+class CalendarEvent(db.Model):
+    __tablename__ = "calendar_events"
+
+    id = db.Column(db.Integer, primary_key=True)
+    user_id = db.Column(db.Integer, db.ForeignKey("users.id"), nullable=False, index=True)
+    title = db.Column(db.String(200), nullable=False)
+    event_type = db.Column(db.String(32), nullable=False, default="other", index=True)
+    start_at = db.Column(db.DateTime, nullable=False, index=True)
+    end_at = db.Column(db.DateTime, nullable=False, index=True)
+    notes = db.Column(db.Text, nullable=True)
+
+    def to_dict(self) -> dict:
+        return {
+            "id": self.id,
+            "title": self.title,
+            "event_type": self.event_type,
+            "start_at": self.start_at.isoformat(timespec="minutes"),
+            "end_at": self.end_at.isoformat(timespec="minutes"),
+            "notes": self.notes or "",
+        }
+
+
+class StudyGroup(db.Model):
+    __tablename__ = "study_groups"
+
+    id = db.Column(db.Integer, primary_key=True)
+    name = db.Column(db.String(200), nullable=False)
+    join_code = db.Column(db.String(16), unique=True, nullable=False, index=True)
+    created_by_user_id = db.Column(db.Integer, db.ForeignKey("users.id"), nullable=False, index=True)
+
+    members = db.relationship(
+        "GroupMember",
+        back_populates="group",
+        lazy="dynamic",
+        cascade="all, delete-orphan",
+    )
+
+    def to_dict(self, *, include_join_code: bool = True) -> dict:
+        d = {
+            "id": self.id,
+            "name": self.name,
+            "created_by_user_id": self.created_by_user_id,
+            "member_count": self.members.count(),
+        }
+        if include_join_code:
+            d["join_code"] = self.join_code
+        return d
+
+
+class GroupMember(db.Model):
+    __tablename__ = "group_members"
+    __table_args__ = (db.UniqueConstraint("group_id", "user_id", name="uq_group_member_user"),)
+
+    id = db.Column(db.Integer, primary_key=True)
+    group_id = db.Column(db.Integer, db.ForeignKey("study_groups.id"), nullable=False, index=True)
+    user_id = db.Column(db.Integer, db.ForeignKey("users.id"), nullable=False, index=True)
+    role = db.Column(db.String(20), nullable=False, default="member")
+
+    group = db.relationship("StudyGroup", back_populates="members")
+
+
+@login_manager.user_loader
+def load_user(user_id: str) -> User | None:
+    if not user_id:
+        return None
+    return db.session.get(User, int(user_id))

--- a/app/services/group_schedule.py
+++ b/app/services/group_schedule.py
@@ -1,0 +1,130 @@
+"""Merged free slots and booking for study groups (lab slice)."""
+
+from __future__ import annotations
+
+from datetime import date, datetime, time, timedelta
+from typing import Any
+
+from app.extensions import db
+from app.models import CalendarEvent, GroupMember, User
+
+
+def monday_of(d: date) -> date:
+    return d - timedelta(days=d.weekday())
+
+
+def week_bounds_mon_fri(monday: date) -> tuple[datetime, datetime]:
+    start = datetime.combine(monday, time.min)
+    end = datetime.combine(monday + timedelta(days=5), time.min)
+    return start, end
+
+
+def _slot_busy_for_user(user_id: int, slot_start: datetime, slot_end: datetime) -> bool:
+    return (
+        CalendarEvent.query.filter_by(user_id=user_id)
+        .filter(CalendarEvent.start_at < slot_end)
+        .filter(CalendarEvent.end_at > slot_start)
+        .first()
+        is not None
+    )
+
+
+def common_free_slots(group_id: int, monday: date, *, slot_minutes: int = 30) -> list[dict[str, Any]]:
+    """Mon–Fri 08:00–20:00 local; slot is free only if no member has a calendar overlap."""
+    members = GroupMember.query.filter_by(group_id=group_id).all()
+    if not members:
+        return []
+    user_ids = [m.user_id for m in members]
+    n = len(user_ids)
+    slot = timedelta(minutes=slot_minutes)
+    day_names = ["Mon", "Tue", "Wed", "Thu", "Fri"]
+    merged: list[dict[str, Any]] = []
+
+    for wd in range(5):
+        d = monday + timedelta(days=wd)
+        day_start = datetime.combine(d, time(8, 0))
+        day_end = datetime.combine(d, time(20, 0))
+        t = day_start
+        while t + slot <= day_end:
+            slot_end = t + slot
+            busy_any = False
+            for uid in user_ids:
+                if _slot_busy_for_user(uid, t, slot_end):
+                    busy_any = True
+                    break
+            if not busy_any:
+                if merged and merged[-1]["end"] == t.isoformat(timespec="minutes"):
+                    merged[-1]["end"] = slot_end.isoformat(timespec="minutes")
+                else:
+                    merged.append(
+                        {
+                            "day": day_names[wd],
+                            "date": d.isoformat(),
+                            "start": t.isoformat(timespec="minutes"),
+                            "end": slot_end.isoformat(timespec="minutes"),
+                            "member_count": n,
+                        }
+                    )
+            t = slot_end
+
+    return merged
+
+
+def _parse_iso_minutes(raw: str) -> datetime:
+    return datetime.fromisoformat(raw.replace("Z", "+00:00"))
+
+
+def interval_covered_by_free_slots(
+    slots: list[dict[str, Any]], start: datetime, end: datetime
+) -> bool:
+    """True if [start, end) lies inside the union of merged free intervals (same logic as common_free_slots output)."""
+    if start >= end:
+        return False
+    for s in slots:
+        s0 = _parse_iso_minutes(s["start"])
+        s1 = _parse_iso_minutes(s["end"])
+        if s0 <= start and s1 >= end:
+            return True
+    return False
+
+
+def book_free_slot_for_user(
+    *,
+    user_id: int,
+    group_id: int,
+    start: datetime,
+    end: datetime,
+    title: str = "Group study (booked)",
+) -> tuple[CalendarEvent | None, str | None]:
+    """
+    If [start, end) is a subset of a common free slot for the group and the user has no overlap, persist one event.
+
+    Returns (event, None) on success, or (None, error_code) where error_code is
+    'not_member' | 'bad_time' | 'not_free' | 'conflict'.
+    """
+    member = GroupMember.query.filter_by(group_id=group_id, user_id=user_id).first()
+    if member is None:
+        return None, "not_member"
+
+    if start >= end:
+        return None, "bad_time"
+
+    monday = monday_of(start.date())
+    free = common_free_slots(group_id, monday)
+    if not interval_covered_by_free_slots(free, start, end):
+        return None, "not_free"
+
+    if _slot_busy_for_user(user_id, start, end):
+        return None, "conflict"
+
+    ev = CalendarEvent(
+        user_id=user_id,
+        title=title,
+        event_type="group_study",
+        start_at=start,
+        end_at=end,
+        notes=f"Booked from group {group_id}",
+    )
+    db.session.add(ev)
+    db.session.commit()
+    return ev, None

--- a/mock_pages/timetable.html
+++ b/mock_pages/timetable.html
@@ -120,7 +120,19 @@
       cursor: pointer;
       transition: all 0.2s;
     }
-    .view-btn.active { background: var(--accent); color: white; }
+    .view-btn.active { background: var(--accent); color: white; cursor: default; }
+    .view-btn:disabled,
+    .view-btn[disabled] {
+      cursor: not-allowed;
+      opacity: 0.42;
+      pointer-events: none;
+    }
+    .view-toggle-hint {
+      font-size: 0.72rem;
+      color: var(--muted);
+      margin-left: 6px;
+      user-select: none;
+    }
 
     .nav-arrows { display: flex; align-items: center; gap: 6px; }
     .arrow-btn {
@@ -325,9 +337,21 @@
   <div class="topbar">
     <div class="topbar-left">
       <div class="page-title">Timetable</div>
-      <div class="view-toggle">
-        <button class="view-btn active"><i class="fas fa-th"></i></button>
-        <button class="view-btn"><i class="fas fa-bars"></i></button>
+      <div class="view-toggle" role="group" aria-label="Timetable layout">
+        <button type="button" class="view-btn active" aria-current="true" title="Weekly grid (current view)" aria-label="Weekly grid view, selected">
+          <i class="fas fa-th" aria-hidden="true"></i>
+        </button>
+        <button
+          type="button"
+          class="view-btn"
+          disabled
+          aria-disabled="true"
+          title="List view is not available in this prototype — only the weekly grid is shown."
+          aria-label="List view: not available"
+        >
+          <i class="fas fa-bars" aria-hidden="true"></i>
+        </button>
+        <span class="view-toggle-hint">Grid only</span>
       </div>
       <div class="nav-arrows">
         <button class="arrow-btn"><i class="fas fa-chevron-left"></i></button>

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+pythonpath = .
+testpaths = tests

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,3 +1,5 @@
 [pytest]
 pythonpath = .
 testpaths = tests
+markers =
+    selenium: browser E2E tests (need Chrome/Chromium; see README)

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ Flask-WTF>=1.2,<2
 SQLAlchemy>=2.0,<3
 Werkzeug>=3.0,<4
 pytest>=8.0,<9
+selenium>=4.24,<5

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,7 @@
+Flask>=3.0,<4
+Flask-Login>=0.6.3
+Flask-SQLAlchemy>=3.1,<4
+Flask-WTF>=1.2,<2
+SQLAlchemy>=2.0,<3
+Werkzeug>=3.0,<4
+pytest>=8.0,<9

--- a/run.py
+++ b/run.py
@@ -1,0 +1,6 @@
+from app import create_app
+
+app = create_app()
+
+if __name__ == "__main__":
+    app.run(host="127.0.0.1", port=5000, debug=True)

--- a/static/js/exam_resources.js
+++ b/static/js/exam_resources.js
@@ -1,0 +1,93 @@
+(function () {
+  const examId = window.__EXAM_ID__;
+  if (!examId) return;
+
+  const $list = $("#resourceList");
+  const $err = $("#resourceError");
+  const $result = $("#resourceResult");
+
+  $.ajaxSetup({
+    beforeSend: function (xhr, settings) {
+      if (!/^(GET|HEAD|OPTIONS|TRACE)$/i.test(settings.type)) {
+        xhr.setRequestHeader("X-CSRFToken", $('meta[name="csrf-token"]').attr("content"));
+      }
+    },
+  });
+
+  function showErr(msg) {
+    if (!msg) {
+      $err.addClass("d-none").text("");
+    } else {
+      $err.removeClass("d-none").text(msg);
+    }
+  }
+
+  function renderRow(r) {
+    const $tr = $("<tr>").attr("data-id", r.id);
+    $tr.append(
+      $("<td>").append(
+        $("<a>", { href: r.url, target: "_blank", rel: "noopener noreferrer" }).text(r.title)
+      )
+    );
+    $tr.append($("<td>").append($("<code>", { class: "small text-break" }).text(r.url)));
+    const $actions = $("<td class=\"text-end\">");
+    const $btnDel = $("<button type=\"button\" class=\"btn btn-outline-danger btn-sm\">Delete</button>");
+    $btnDel.on("click", function () {
+      if (!window.confirm("Remove this resource?")) return;
+      $btnDel.prop("disabled", true);
+      $.ajax({ url: "/api/exams/" + examId + "/resources/" + r.id, method: "DELETE" })
+        .done(function () {
+          $tr.remove();
+          $result.text("Deleted resource #" + r.id);
+        })
+        .fail(function (xhr) {
+          const msg = (xhr.responseJSON && xhr.responseJSON.error) || xhr.statusText;
+          showErr(msg);
+        })
+        .always(function () {
+          $btnDel.prop("disabled", false);
+        });
+    });
+    $actions.append($btnDel);
+    $tr.append($actions);
+    return $tr;
+  }
+
+  function loadList() {
+    showErr("");
+    $.getJSON("/api/exams/" + examId + "/resources")
+      .done(function (data) {
+        $list.empty();
+        (data.resources || []).forEach(function (r) {
+          $list.append(renderRow(r));
+        });
+      })
+      .fail(function (xhr) {
+        showErr((xhr.responseJSON && xhr.responseJSON.error) || xhr.statusText);
+      });
+  }
+
+  $("#formAddResource").on("submit", function (e) {
+    e.preventDefault();
+    const title = $("#resTitle").val().trim();
+    const url = $("#resUrl").val().trim();
+    showErr("");
+    $.ajax({
+      url: "/api/exams/" + examId + "/resources",
+      method: "POST",
+      contentType: "application/json",
+      data: JSON.stringify({ title: title, url: url }),
+    })
+      .done(function (res) {
+        $("#resTitle, #resUrl").val("");
+        $list.append(renderRow(res.resource));
+        $result.text("Added resource #" + res.resource.id);
+      })
+      .fail(function (xhr) {
+        const msg = (xhr.responseJSON && xhr.responseJSON.error) || xhr.statusText;
+        showErr(msg);
+      });
+  });
+
+  loadList();
+})();

--- a/static/js/exam_share.js
+++ b/static/js/exam_share.js
@@ -1,0 +1,81 @@
+(function () {
+  const $panel = $("#sharePanel");
+  if (!$panel.length) return;
+  const examId = $panel.data("exam-id");
+  if (!examId) return;
+
+  const $active = $("#shareActive");
+  const $inactive = $("#shareInactive");
+  const $input = $("#shareUrlInput");
+  const $err = $("#shareError");
+
+  $.ajaxSetup({
+    beforeSend: function (xhr, settings) {
+      if (!/^(GET|HEAD|OPTIONS|TRACE)$/i.test(settings.type)) {
+        xhr.setRequestHeader("X-CSRFToken", $('meta[name="csrf-token"]').attr("content"));
+      }
+    },
+  });
+
+  function showErr(msg) {
+    if (!msg) {
+      $err.addClass("d-none").text("");
+    } else {
+      $err.removeClass("d-none").text(msg);
+    }
+  }
+
+  function showActive(url) {
+    $input.val(url);
+    $active.removeClass("d-none");
+    $inactive.addClass("d-none");
+  }
+
+  function showInactive() {
+    $input.val("");
+    $active.addClass("d-none");
+    $inactive.removeClass("d-none");
+  }
+
+  $("#btnCreateShare").on("click", function () {
+    const $btn = $(this).prop("disabled", true);
+    showErr("");
+    $.post("/api/exams/" + examId + "/share-token")
+      .done(function (res) {
+        showActive(res.share_url || "");
+      })
+      .fail(function (xhr) {
+        const msg = (xhr.responseJSON && xhr.responseJSON.error) || xhr.statusText;
+        showErr(msg);
+      })
+      .always(function () {
+        $btn.prop("disabled", false);
+      });
+  });
+
+  $("#btnRevokeShare").on("click", function () {
+    if (!window.confirm("Revoke this share link? It will stop working for everyone.")) return;
+    const $btn = $(this).prop("disabled", true);
+    showErr("");
+    $.ajax({ url: "/api/exams/" + examId + "/share-token", method: "DELETE" })
+      .done(function () {
+        showInactive();
+      })
+      .fail(function (xhr) {
+        const msg = (xhr.responseJSON && xhr.responseJSON.error) || xhr.statusText;
+        showErr(msg);
+      })
+      .always(function () {
+        $btn.prop("disabled", false);
+      });
+  });
+
+  $("#btnCopyShare").on("click", function () {
+    const v = $input.val();
+    if (!v) return;
+    navigator.clipboard.writeText(v).catch(function () {
+      $input.select();
+      document.execCommand("copy");
+    });
+  });
+})();

--- a/templates/exam_detail.html
+++ b/templates/exam_detail.html
@@ -1,0 +1,89 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8"/>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+  <meta name="csrf-token" content="{{ csrf_token() }}"/>
+  <title>{% if exam %}{{ exam.title }}{% else %}Exam{% endif %} — AgileWebDevLab</title>
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet"/>
+</head>
+<body class="bg-dark text-light">
+  <nav class="navbar navbar-dark border-bottom border-secondary mb-4">
+    <div class="container-fluid">
+      <span class="navbar-brand mb-0 h1">AgileWebDevLab</span>
+      <div class="d-flex gap-2 align-items-center">
+        <a class="btn btn-outline-light btn-sm" href="{{ url_for('exams.exams_list') }}">Exams</a>
+        <a class="btn btn-outline-light btn-sm" href="{{ url_for('group_book.group_page', group_id=1) }}">Group</a>
+        <form method="post" action="{{ url_for('auth.logout_post') }}" class="d-inline">
+          <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
+          <button type="submit" class="btn btn-outline-light btn-sm">Log out</button>
+        </form>
+      </div>
+    </div>
+  </nav>
+
+  <div class="container pb-5">
+    {% if not exam %}
+      <div class="alert alert-warning">Exam not found or you do not have access.</div>
+    {% else %}
+      <nav aria-label="breadcrumb">
+        <ol class="breadcrumb">
+          <li class="breadcrumb-item"><a href="{{ url_for('exams.exams_list') }}">Exams</a></li>
+          <li class="breadcrumb-item active" aria-current="page">{{ exam.title }}</li>
+        </ol>
+      </nav>
+      <h2 class="h4 mb-1">{{ exam.title }}</h2>
+      <p class="text-secondary small mb-4">
+        {{ exam.course_code or "No course code" }} ·
+        {{ exam.starts_at.strftime("%Y-%m-%d %H:%M") }} – {{ exam.ends_at.strftime("%H:%M") }}
+      </p>
+      {% if exam.notes %}
+        <p class="small mb-4">{{ exam.notes }}</p>
+      {% endif %}
+
+      <div class="card bg-secondary bg-opacity-25 border-secondary mb-4">
+        <div class="card-header border-secondary">Structured resources</div>
+        <div class="card-body">
+          <p class="small text-secondary">Multiple links per exam session (title + URL). Only <code>http</code> or <code>https</code> URLs are accepted.</p>
+
+          <form id="formAddResource" class="row g-2 align-items-end mb-3">
+            <div class="col-md-4">
+              <label class="form-label small mb-0" for="resTitle">Title</label>
+              <input class="form-control form-control-sm" id="resTitle" required maxlength="200" placeholder="Past paper PDF"/>
+            </div>
+            <div class="col-md-6">
+              <label class="form-label small mb-0" for="resUrl">URL</label>
+              <input class="form-control form-control-sm" id="resUrl" type="url" required maxlength="2048" placeholder="https://…"/>
+            </div>
+            <div class="col-md-2">
+              <button type="submit" class="btn btn-primary btn-sm w-100">Add</button>
+            </div>
+          </form>
+
+          <p id="resourceError" class="text-danger small d-none mb-2"></p>
+          <p id="resourceResult" class="text-info small mb-2"></p>
+
+          <div class="table-responsive">
+            <table class="table table-dark table-sm table-bordered align-middle mb-0">
+              <thead>
+                <tr>
+                  <th>Title</th>
+                  <th>URL</th>
+                  <th class="text-end" style="width:6rem">Actions</th>
+                </tr>
+              </thead>
+              <tbody id="resourceList"></tbody>
+            </table>
+          </div>
+        </div>
+      </div>
+    {% endif %}
+  </div>
+
+  {% if exam %}
+  <script>window.__EXAM_ID__ = {{ exam_id|tojson }};</script>
+  <script src="https://code.jquery.com/jquery-3.7.1.min.js" integrity="sha256-/JqT3SQfawRcv/BIHPThkBvs0OEvtFFmqPF/lYI/Cxo=" crossorigin="anonymous"></script>
+  <script src="{{ url_for('static', filename='js/exam_resources.js') }}"></script>
+  {% endif %}
+</body>
+</html>

--- a/templates/exam_detail.html
+++ b/templates/exam_detail.html
@@ -42,6 +42,30 @@
       {% endif %}
 
       <div class="card bg-secondary bg-opacity-25 border-secondary mb-4">
+        <div class="card-header border-secondary">Read-only share link</div>
+        <div class="card-body">
+          <p class="small text-secondary mb-3">
+            Anyone with the link can open a <strong>read-only</strong> page (no account). Revoking immediately invalidates the URL.
+          </p>
+          <div id="sharePanel" data-exam-id="{{ exam_id }}">
+            <div id="shareActive" class="{% if not share_url %}d-none{% endif %}">
+              <label class="form-label small mb-0" for="shareUrlInput">Share URL</label>
+              <div class="input-group input-group-sm mb-2">
+                <input type="text" class="form-control text-secondary" id="shareUrlInput" readonly
+                       value="{{ share_url or '' }}"/>
+                <button type="button" class="btn btn-outline-secondary" id="btnCopyShare">Copy</button>
+              </div>
+              <button type="button" class="btn btn-outline-warning btn-sm" id="btnRevokeShare">Revoke link</button>
+            </div>
+            <div id="shareInactive" class="{% if share_url %}d-none{% endif %}">
+              <button type="button" class="btn btn-outline-primary btn-sm" id="btnCreateShare">Create share link</button>
+            </div>
+            <p id="shareError" class="text-danger small d-none mb-0 mt-2"></p>
+          </div>
+        </div>
+      </div>
+
+      <div class="card bg-secondary bg-opacity-25 border-secondary mb-4">
         <div class="card-header border-secondary">Structured resources</div>
         <div class="card-body">
           <p class="small text-secondary">Multiple links per exam session (title + URL). Only <code>http</code> or <code>https</code> URLs are accepted.</p>
@@ -83,6 +107,7 @@
   {% if exam %}
   <script>window.__EXAM_ID__ = {{ exam_id|tojson }};</script>
   <script src="https://code.jquery.com/jquery-3.7.1.min.js" integrity="sha256-/JqT3SQfawRcv/BIHPThkBvs0OEvtFFmqPF/lYI/Cxo=" crossorigin="anonymous"></script>
+  <script src="{{ url_for('static', filename='js/exam_share.js') }}"></script>
   <script src="{{ url_for('static', filename='js/exam_resources.js') }}"></script>
   {% endif %}
 </body>

--- a/templates/exam_shared_public.html
+++ b/templates/exam_shared_public.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8"/>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+  <title>{% if ok %}{{ exam.title }} (shared){% else %}Shared exam{% endif %} — AgileWebDevLab</title>
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet"/>
+</head>
+<body class="bg-dark text-light">
+  <nav class="navbar navbar-dark border-bottom border-secondary mb-4">
+    <div class="container-fluid">
+      <span class="navbar-brand mb-0 h1">AgileWebDevLab</span>
+      <span class="badge bg-secondary">Read-only share</span>
+    </div>
+  </nav>
+
+  <div class="container pb-5" style="max-width: 720px;">
+    {% if not ok %}
+      <div class="alert alert-secondary border-secondary">
+        This share link is invalid or has been removed.
+      </div>
+      <p class="small text-secondary mb-0">If you expected a study plan here, ask the owner for a new link.</p>
+    {% else %}
+      <p class="small text-info mb-3">You are viewing a <strong>read-only</strong> copy. Sign-in is not required.</p>
+      <h1 class="h4 mb-1">{{ exam.title }}</h1>
+      <p class="text-secondary small mb-3">
+        {{ exam.course_code or "Course TBC" }} ·
+        {{ exam.starts_at.strftime("%Y-%m-%d %H:%M") }} – {{ exam.ends_at.strftime("%H:%M") }}
+      </p>
+      {% if exam.notes %}
+        <div class="card bg-secondary bg-opacity-25 border-secondary mb-4">
+          <div class="card-body small">{{ exam.notes }}</div>
+        </div>
+      {% endif %}
+
+      <h2 class="h6 text-uppercase text-secondary mb-2">Resources</h2>
+      {% if not resources %}
+        <p class="text-secondary small">No links attached to this exam.</p>
+      {% else %}
+        <ul class="list-group list-group-dark">
+          {% for r in resources %}
+            <li class="list-group-item list-group-item-dark d-flex justify-content-between align-items-start gap-2">
+              <a href="{{ r.url }}" target="_blank" rel="noopener noreferrer" class="link-light">{{ r.title }}</a>
+              <span class="small text-secondary text-break" style="max-width: 45%;">{{ r.url }}</span>
+            </li>
+          {% endfor %}
+        </ul>
+      {% endif %}
+    {% endif %}
+  </div>
+</body>
+</html>

--- a/templates/exams_list.html
+++ b/templates/exams_list.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8"/>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+  <meta name="csrf-token" content="{{ csrf_token() }}"/>
+  <title>Exams — AgileWebDevLab</title>
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet"/>
+</head>
+<body class="bg-dark text-light">
+  <nav class="navbar navbar-dark border-bottom border-secondary mb-4">
+    <div class="container-fluid">
+      <span class="navbar-brand mb-0 h1">AgileWebDevLab</span>
+      <div class="d-flex gap-2 align-items-center">
+        <a class="btn btn-outline-light btn-sm" href="{{ url_for('exams.exams_list') }}">Exams</a>
+        <a class="btn btn-outline-light btn-sm" href="{{ url_for('group_book.group_page', group_id=1) }}">Group</a>
+        <form method="post" action="{{ url_for('auth.logout_post') }}" class="d-inline">
+          <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
+          <button type="submit" class="btn btn-outline-light btn-sm">Log out</button>
+        </form>
+      </div>
+    </div>
+  </nav>
+  <div class="container pb-5">
+    <h2 class="h4 mb-3">My exam sessions</h2>
+    {% if not exams %}
+      <p class="text-secondary">No exams yet. Run the app once after install so seed data can create a sample session, or add exams via your own workflow.</p>
+    {% else %}
+      <div class="list-group">
+        {% for e in exams %}
+          <a class="list-group-item list-group-item-action list-group-item-dark d-flex justify-content-between align-items-center"
+             href="{{ url_for('exams.exam_detail', exam_id=e.id) }}">
+            <div>
+              <div class="fw-semibold">{{ e.title }}</div>
+              <div class="small text-secondary">{{ e.course_code or "—" }} · {{ e.starts_at.strftime("%Y-%m-%d %H:%M") }}</div>
+            </div>
+            <span class="badge bg-secondary">{{ e.resources.count() }} resources</span>
+          </a>
+        {% endfor %}
+      </div>
+    {% endif %}
+  </div>
+</body>
+</html>

--- a/templates/group_book.html
+++ b/templates/group_book.html
@@ -11,10 +11,14 @@
   <nav class="navbar navbar-dark border-bottom border-secondary mb-4">
     <div class="container-fluid">
       <span class="navbar-brand mb-0 h1">AgileWebDevLab</span>
-      <form method="post" action="{{ url_for('auth.logout_post') }}" class="d-inline">
-        <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
-        <button type="submit" class="btn btn-outline-light btn-sm">Log out</button>
-      </form>
+      <div class="d-flex gap-2 align-items-center">
+        <a class="btn btn-outline-light btn-sm" href="{{ url_for('exams.exams_list') }}">Exams</a>
+        <a class="btn btn-outline-light btn-sm" href="{{ url_for('group_book.group_page', group_id=1) }}">Group</a>
+        <form method="post" action="{{ url_for('auth.logout_post') }}" class="d-inline">
+          <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
+          <button type="submit" class="btn btn-outline-light btn-sm">Log out</button>
+        </form>
+      </div>
     </div>
   </nav>
 
@@ -23,7 +27,7 @@
       <div class="alert alert-warning">Group not found or you are not a member.</div>
     {% else %}
       <h2 class="h4 mb-1">{{ group.name }}</h2>
-      <p class="text-secondary small mb-4">Join code: <code>{{ group.join_code }}</code> — Issue #1: book a common free slot; it is saved as <strong>your</strong> calendar event (<code>event_type=group_study</code>).</p>
+      <p class="text-secondary small mb-4">Join code: <code>{{ group.join_code }}</code>. Book a common free slot; it is saved as <strong>your</strong> calendar event (<code>event_type=group_study</code>).</p>
 
       <div class="row g-4">
         <div class="col-lg-6">

--- a/templates/group_book.html
+++ b/templates/group_book.html
@@ -1,0 +1,117 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8"/>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+  <meta name="csrf-token" content="{{ csrf_token() }}"/>
+  <title>{% if group %}{{ group.name }}{% else %}Group{% endif %} — Book free slot</title>
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet"/>
+</head>
+<body class="bg-dark text-light">
+  <nav class="navbar navbar-dark border-bottom border-secondary mb-4">
+    <div class="container-fluid">
+      <span class="navbar-brand mb-0 h1">AgileWebDevLab</span>
+      <form method="post" action="{{ url_for('auth.logout_post') }}" class="d-inline">
+        <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
+        <button type="submit" class="btn btn-outline-light btn-sm">Log out</button>
+      </form>
+    </div>
+  </nav>
+
+  <div class="container pb-5">
+    {% if not group %}
+      <div class="alert alert-warning">Group not found or you are not a member.</div>
+    {% else %}
+      <h2 class="h4 mb-1">{{ group.name }}</h2>
+      <p class="text-secondary small mb-4">Join code: <code>{{ group.join_code }}</code> — Issue #1: book a common free slot; it is saved as <strong>your</strong> calendar event (<code>event_type=group_study</code>).</p>
+
+      <div class="row g-4">
+        <div class="col-lg-6">
+          <div class="card bg-secondary bg-opacity-25 border-secondary">
+            <div class="card-header border-secondary">Common free slots (this week)</div>
+            <div class="card-body">
+              <p class="small text-secondary mb-2" id="weekLabel"></p>
+              <div id="slotList" class="d-flex flex-column gap-2"></div>
+              <p id="slotError" class="text-danger small d-none mb-0"></p>
+            </div>
+          </div>
+        </div>
+        <div class="col-lg-6">
+          <div class="card bg-secondary bg-opacity-25 border-secondary">
+            <div class="card-header border-secondary">Last booking result</div>
+            <div class="card-body">
+              <pre id="result" class="small text-info mb-0" style="white-space: pre-wrap;">—</pre>
+            </div>
+          </div>
+        </div>
+      </div>
+    {% endif %}
+  </div>
+
+  {% if group %}
+  <script src="https://code.jquery.com/jquery-3.7.1.min.js" integrity="sha256-/JqT3SQfawRcv/BIHPThkBvs0OEvtFFmqPF/lYI/Cxo=" crossorigin="anonymous"></script>
+  <script>
+    (function () {
+      const GROUP_ID = {{ group_id|tojson }};
+      const weekStart = {{ week_start_iso|tojson }};
+      $("#weekLabel").text("week_start=" + weekStart);
+
+      $.ajaxSetup({
+        beforeSend: function (xhr, settings) {
+          if (!/^(GET|HEAD|OPTIONS|TRACE)$/i.test(settings.type)) {
+            xhr.setRequestHeader("X-CSRFToken", $('meta[name="csrf-token"]').attr("content"));
+          }
+        }
+      });
+
+      function loadSlots() {
+        $("#slotError").addClass("d-none").text("");
+        $.getJSON("/api/groups/" + GROUP_ID + "/free-slots", { week_start: weekStart })
+          .done(function (data) {
+            const $list = $("#slotList").empty();
+            const slots = data.slots || [];
+            if (!slots.length) {
+              $list.append("<span class='text-secondary'>No common free slots for this week (try another account or adjust seed data).</span>");
+              return;
+            }
+            slots.forEach(function (s) {
+              const label = s.day + " " + s.start.slice(11, 16) + "–" + s.end.slice(11, 16);
+              const $btn = $("<button type='button' class='btn btn-success btn-sm'>Book</button>");
+              $btn.on("click", function () {
+                $btn.prop("disabled", true);
+                $.ajax({
+                  url: "/api/groups/" + GROUP_ID + "/book-free-slot",
+                  method: "POST",
+                  contentType: "application/json",
+                  data: JSON.stringify({ start: s.start, end: s.end })
+                })
+                  .done(function (res) {
+                    $("#result").text(JSON.stringify(res, null, 2));
+                  })
+                  .fail(function (xhr) {
+                    const msg = (xhr.responseJSON && xhr.responseJSON.error) || xhr.statusText;
+                    $("#result").text("Error: " + msg);
+                  })
+                  .always(function () {
+                    $btn.prop("disabled", false);
+                    loadSlots();
+                  });
+              });
+              $list.append(
+                $("<div class='d-flex align-items-center justify-content-between border border-secondary rounded px-3 py-2'></div>")
+                  .append($("<span></span>").text(label))
+                  .append($btn)
+              );
+            });
+          })
+          .fail(function (xhr) {
+            const msg = (xhr.responseJSON && xhr.responseJSON.error) || xhr.statusText;
+            $("#slotError").removeClass("d-none").text(msg);
+          });
+      }
+      loadSlots();
+    })();
+  </script>
+  {% endif %}
+</body>
+</html>

--- a/templates/login.html
+++ b/templates/login.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8"/>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+  <title>Sign in — AgileWebDevLab</title>
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet"/>
+</head>
+<body class="bg-light">
+  <div class="container py-5" style="max-width: 420px;">
+    <h1 class="h4 mb-4">AgileWebDevLab — demo login</h1>
+    {% with messages = get_flashed_messages(with_categories=true) %}
+      {% if messages %}
+        {% for category, message in messages %}
+          <div class="alert alert-{{ category }}">{{ message }}</div>
+        {% endfor %}
+      {% endif %}
+    {% endwith %}
+    <form method="post" action="{{ url_for('auth.login_post') }}" class="card shadow-sm p-4">
+      <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
+      <div class="mb-3">
+        <label class="form-label" for="email">Email</label>
+        <input class="form-control" id="email" name="email" type="email" required
+               placeholder="alice@lab.local" autocomplete="username"/>
+      </div>
+      <div class="mb-3">
+        <label class="form-label" for="password">Password</label>
+        <input class="form-control" id="password" name="password" type="password" required
+               placeholder="labdemo123" autocomplete="current-password"/>
+      </div>
+      <button type="submit" class="btn btn-primary w-100">Sign in</button>
+    </form>
+    <p class="text-muted small mt-3 mb-0">Seeded users: <code>alice@lab.local</code> / <code>bob@lab.local</code> — password <code>labdemo123</code>.</p>
+  </div>
+</body>
+</html>

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from app import create_app
+from app.config import Config
+
+
+class TestConfig(Config):
+    TESTING = True
+    WTF_CSRF_ENABLED = False
+
+
+@pytest.fixture()
+def app(tmp_path: Path):
+    class TC(TestConfig):
+        SQLALCHEMY_DATABASE_URI = "sqlite:///" + str(tmp_path / "test.db")
+
+    application = create_app(TC)
+    yield application
+
+
+@pytest.fixture()
+def client(app):
+    return app.test_client()

--- a/tests/selenium/conftest.py
+++ b/tests/selenium/conftest.py
@@ -1,0 +1,73 @@
+"""Live WSGI server + WebDriver fixtures for browser E2E tests."""
+
+from __future__ import annotations
+
+import os
+import socket
+import threading
+from pathlib import Path
+
+import pytest
+from werkzeug.serving import make_server
+
+from app import create_app
+from app.config import Config
+
+
+class E2EAppConfig(Config):
+    """Exercise real form CSRF paths (same as normal dev, not the unit-test shortcut)."""
+
+    TESTING = True
+    WTF_CSRF_ENABLED = True
+
+
+def _free_port() -> int:
+    s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    s.bind(("127.0.0.1", 0))
+    port = int(s.getsockname()[1])
+    s.close()
+    return port
+
+
+@pytest.fixture(scope="module")
+def selenium_live_server(tmp_path_factory: pytest.TempPathFactory) -> str:
+    """Real HTTP server on localhost; same process as tests, separate thread."""
+    db_dir = tmp_path_factory.mktemp("selenium_sqlite")
+    db_path: Path = db_dir / "live.db"
+
+    class TC(E2EAppConfig):
+        SQLALCHEMY_DATABASE_URI = f"sqlite:///{db_path}"
+
+    application = create_app(TC)
+    port = _free_port()
+    httpd = make_server("127.0.0.1", port, application, threaded=True)
+    thread = threading.Thread(target=httpd.serve_forever, daemon=True)
+    thread.start()
+    base = f"http://127.0.0.1:{port}"
+    try:
+        yield base
+    finally:
+        httpd.shutdown()
+        thread.join(timeout=10.0)
+
+
+@pytest.fixture()
+def driver():
+    from selenium import webdriver
+    from selenium.webdriver.chrome.options import Options as ChromeOptions
+
+    opts = ChromeOptions()
+    if os.environ.get("HEADLESS", "1").lower() not in ("0", "false", "no"):
+        opts.add_argument("--headless=new")
+    opts.add_argument("--no-sandbox")
+    opts.add_argument("--disable-dev-shm-usage")
+    opts.add_argument("--disable-gpu")
+    opts.add_argument("--window-size=1280,800")
+
+    try:
+        drv = webdriver.Chrome(options=opts)
+    except Exception as exc:  # noqa: BLE001 — surface skip reason to developers
+        pytest.skip(f"Chrome / WebDriver not available for Selenium: {exc}")
+
+    yield drv
+    drv.quit()

--- a/tests/selenium/test_auth_e2e.py
+++ b/tests/selenium/test_auth_e2e.py
@@ -1,0 +1,47 @@
+"""End-to-end flows against a live dev server (see tests/selenium/conftest.py)."""
+
+from __future__ import annotations
+
+from urllib.parse import urlparse
+
+import pytest
+from selenium.webdriver.common.by import By
+from selenium.webdriver.support import expected_conditions as EC
+from selenium.webdriver.support.ui import WebDriverWait
+
+pytestmark = pytest.mark.selenium
+
+
+def test_login_happy_path_reaches_exams_list(selenium_live_server: str, driver) -> None:
+    driver.get(f"{selenium_live_server}/login")
+    wait = WebDriverWait(driver, 15)
+
+    wait.until(EC.presence_of_element_located((By.ID, "email")))
+    driver.find_element(By.ID, "email").clear()
+    driver.find_element(By.ID, "email").send_keys("alice@lab.local")
+    driver.find_element(By.ID, "password").clear()
+    driver.find_element(By.ID, "password").send_keys("labdemo123")
+    driver.find_element(By.CSS_SELECTOR, "button[type='submit']").click()
+
+    wait.until(EC.title_contains("Exams"))
+    path = urlparse(driver.current_url).path.rstrip("/")
+    assert path == "/exams" or path.endswith("/exams")
+    wait.until(EC.presence_of_element_located((By.XPATH, "//h2[contains(., 'My exam sessions')]")))
+
+
+def test_login_wrong_password_shows_error_and_stays_unauthenticated(selenium_live_server: str, driver) -> None:
+    driver.get(f"{selenium_live_server}/login")
+    wait = WebDriverWait(driver, 15)
+
+    wait.until(EC.presence_of_element_located((By.ID, "email")))
+    driver.find_element(By.ID, "email").clear()
+    driver.find_element(By.ID, "email").send_keys("alice@lab.local")
+    driver.find_element(By.ID, "password").clear()
+    driver.find_element(By.ID, "password").send_keys("wrong-password-for-sure")
+    driver.find_element(By.CSS_SELECTOR, "button[type='submit']").click()
+
+    wait.until(EC.presence_of_element_located((By.CSS_SELECTOR, ".alert-danger")))
+    assert "invalid" in driver.find_element(By.CSS_SELECTOR, ".alert-danger").text.lower()
+
+    driver.get(f"{selenium_live_server}/exams")
+    wait.until(EC.url_contains("/login"))

--- a/tests/test_exam_resources.py
+++ b/tests/test_exam_resources.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+
+def _login(client, email: str = "alice@lab.local"):
+    return client.post(
+        "/login",
+        data={"email": email, "password": "labdemo123"},
+        follow_redirects=True,
+    )
+
+
+def test_exam_resources_list_requires_owner(client):
+    _login(client, "alice@lab.local")
+    rv = client.get("/api/exams/1/resources")
+    assert rv.status_code == 200
+    data = rv.get_json()
+    assert "resources" in data
+    assert len(data["resources"]) >= 1
+
+
+def test_exam_resources_forbidden_for_other_user(client):
+    _login(client, "bob@lab.local")
+    rv = client.get("/api/exams/1/resources")
+    assert rv.status_code == 404
+
+
+def test_create_resource_validation(client):
+    _login(client, "alice@lab.local")
+    rv = client.post(
+        "/api/exams/1/resources",
+        json={"title": "Bad", "url": "ftp://example.com/file"},
+        headers={"Content-Type": "application/json"},
+    )
+    assert rv.status_code == 400
+    assert "http" in (rv.get_json() or {}).get("error", "").lower()
+
+
+def test_create_and_patch_and_delete_resource(client):
+    _login(client, "alice@lab.local")
+    rv = client.post(
+        "/api/exams/1/resources",
+        json={"title": "Lecture notes", "url": "https://example.org/notes"},
+        headers={"Content-Type": "application/json"},
+    )
+    assert rv.status_code == 201
+    rid = rv.get_json()["resource"]["id"]
+
+    patch = client.patch(
+        f"/api/exams/1/resources/{rid}",
+        json={"title": "Lecture notes (updated)", "sort_order": 5},
+        headers={"Content-Type": "application/json"},
+    )
+    assert patch.status_code == 200
+    assert patch.get_json()["resource"]["title"].startswith("Lecture")
+    assert patch.get_json()["resource"]["sort_order"] == 5
+
+    delete = client.delete(f"/api/exams/1/resources/{rid}")
+    assert delete.status_code == 204
+
+    again = client.get("/api/exams/1/resources")
+    ids = [r["id"] for r in again.get_json()["resources"]]
+    assert rid not in ids

--- a/tests/test_exam_share.py
+++ b/tests/test_exam_share.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+
+def _login(client, email: str = "alice@lab.local"):
+    return client.post(
+        "/login",
+        data={"email": email, "password": "labdemo123"},
+        follow_redirects=True,
+    )
+
+
+def test_share_token_requires_auth(client):
+    rv = client.post("/api/exams/1/share-token")
+    assert rv.status_code == 401
+
+
+def test_share_public_flow_generate_view_revoke(client):
+    _login(client, "alice@lab.local")
+    gen = client.post("/api/exams/1/share-token")
+    assert gen.status_code == 201
+    data = gen.get_json()
+    assert "share_token" in data and "share_url" in data
+    token = data["share_token"]
+    assert len(token) >= 32
+
+    pub = client.get(f"/exams/shared/{token}")
+    assert pub.status_code == 200
+    assert b"Read-only" in pub.data
+    assert b"Practice exam" in pub.data
+
+    bad = client.get("/exams/shared/invalid-token-xxxxxxxxxxxx")
+    assert bad.status_code == 404
+    assert b"invalid" in bad.data.lower() or b"removed" in bad.data.lower()
+
+    rv = client.delete("/api/exams/1/share-token")
+    assert rv.status_code == 204
+
+    after = client.get(f"/exams/shared/{token}")
+    assert after.status_code == 404
+
+
+def test_share_token_forbidden_for_non_owner(client):
+    _login(client, "bob@lab.local")
+    rv = client.post("/api/exams/1/share-token")
+    assert rv.status_code == 404

--- a/tests/test_group_book.py
+++ b/tests/test_group_book.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+from datetime import date, datetime, time, timedelta
+
+
+def _monday():
+    d = date.today()
+    return d - timedelta(days=d.weekday())
+
+
+def test_api_free_slots_requires_auth(client):
+    ws = _monday().isoformat()
+    rv = client.get(f"/api/groups/1/free-slots?week_start={ws}")
+    assert rv.status_code == 401
+
+
+def test_book_flow_happy_path_then_conflict(client):
+    client.post(
+        "/login",
+        data={"email": "alice@lab.local", "password": "labdemo123"},
+        follow_redirects=True,
+    )
+    ws = _monday().isoformat()
+    rv = client.get(f"/api/groups/1/free-slots?week_start={ws}")
+    assert rv.status_code == 200
+    payload = rv.get_json()
+    assert "slots" in payload
+    slots = payload["slots"]
+    assert isinstance(slots, list)
+    assert len(slots) >= 1
+    slot = slots[0]
+    book = client.post(
+        "/api/groups/1/book-free-slot",
+        json={"start": slot["start"], "end": slot["end"]},
+        headers={"Content-Type": "application/json"},
+    )
+    assert book.status_code == 201
+    ev = book.get_json()["event"]
+    assert ev["event_type"] == "group_study"
+
+    again = client.post(
+        "/api/groups/1/book-free-slot",
+        json={"start": slot["start"], "end": slot["end"]},
+        headers={"Content-Type": "application/json"},
+    )
+    assert again.status_code == 409
+
+
+def test_book_rejects_interval_outside_common_free_grid(client):
+    client.post(
+        "/login",
+        data={"email": "alice@lab.local", "password": "labdemo123"},
+        follow_redirects=True,
+    )
+    monday = _monday()
+    # Interval clearly outside Mon–Fri 08:00–20:00 free grid
+    start = datetime.combine(monday, time(6, 0))
+    end = datetime.combine(monday, time(6, 30))
+    rv = client.post(
+        "/api/groups/1/book-free-slot",
+        json={"start": start.isoformat(timespec="minutes"), "end": end.isoformat(timespec="minutes")},
+        headers={"Content-Type": "application/json"},
+    )
+    assert rv.status_code == 409
+    assert "not inside" in (rv.get_json() or {}).get("error", "").lower()


### PR DESCRIPTION
## Summary
Fixes misleading **list / grid** controls on the static **timetable mock** (`mock_pages/timetable.html`). Only the **weekly grid** is implemented in this prototype; the list-style control is now **explicitly disabled** with accessible labels and a short **“Grid only”** hint so users and markers do not interpret it as a broken interactive toggle.

## Changes
- List button: `disabled`, `aria-disabled="true"`, `title` and `aria-label` explaining list view is not available here.
- Grid button: `type="button"`, `aria-current`, descriptive `title` / `aria-label`.
- CSS: disabled state styling (reduced opacity, no pointer events); active grid button not shown as a pointer cursor.
- `README.md`: one-line clarification under repository layout for `mock_pages/` timetable behaviour.

## Out of scope
Implementing a real **list view** for the mock (or a Flask `/timetable` page) remains a separate feature if the group later chooses Track A.

## How to review
Open `mock_pages/timetable.html` in a browser: confirm the bars icon cannot be focused/activated as a normal control and the native tooltip explains why.

Closes #18 