### PR TITLE
Add database models and seed data

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -18,10 +18,19 @@ def create_app():
 
     @login_manager.user_loader
     def load_user(user_id):
-        # Temporary loader for Stage 1.
-        # We do not have real users yet, so return None.
-        return None
+        from app.models import User
+        return User.query.get(int(user_id))
 
     app.register_blueprint(main_bp)
+
+    @app.cli.command("init-db")
+    def init_db_command():
+        from app.seed import seed_demo_data
+
+        db.drop_all()
+        db.create_all()
+        seed_demo_data()
+
+        print("Database initialised successfully.")
 
     return app

--- a/app/models.py
+++ b/app/models.py
@@ -1,0 +1,171 @@
+from datetime import datetime
+
+from flask_login import UserMixin
+from werkzeug.security import generate_password_hash, check_password_hash
+
+from app.extensions import db
+
+
+class User(UserMixin, db.Model):
+    __tablename__ = "users"
+
+    id = db.Column(db.Integer, primary_key=True)
+    full_name = db.Column(db.String(120), nullable=False)
+    email = db.Column(db.String(160), unique=True, nullable=False)
+    uwa_id = db.Column(db.String(30), nullable=True)
+    program = db.Column(db.String(120), nullable=True)
+    bio = db.Column(db.Text, nullable=True)
+    skills = db.Column(db.String(250), nullable=True)
+    availability = db.Column(db.String(250), nullable=True)
+    avatar_colour = db.Column(db.String(30), default="purple")
+    password_hash = db.Column(db.String(255), nullable=False)
+    created_at = db.Column(db.DateTime, default=datetime.utcnow)
+
+    def set_password(self, password):
+        self.password_hash = generate_password_hash(password)
+
+    def check_password(self, password):
+        return check_password_hash(self.password_hash, password)
+
+
+class Course(db.Model):
+    __tablename__ = "courses"
+
+    id = db.Column(db.Integer, primary_key=True)
+    code = db.Column(db.String(20), nullable=False)
+    title = db.Column(db.String(160), nullable=False)
+    description = db.Column(db.Text, nullable=True)
+    owner_id = db.Column(db.Integer, db.ForeignKey("users.id"), nullable=False)
+
+    owner = db.relationship("User", backref="courses")
+
+
+class TimetableEvent(db.Model):
+    __tablename__ = "timetable_events"
+
+    id = db.Column(db.Integer, primary_key=True)
+    title = db.Column(db.String(160), nullable=False)
+    event_type = db.Column(db.String(40), nullable=False)
+    location = db.Column(db.String(120), nullable=True)
+    start_time = db.Column(db.DateTime, nullable=False)
+    end_time = db.Column(db.DateTime, nullable=False)
+    is_group_event = db.Column(db.Boolean, default=False)
+    owner_id = db.Column(db.Integer, db.ForeignKey("users.id"), nullable=False)
+    course_id = db.Column(db.Integer, db.ForeignKey("courses.id"), nullable=True)
+
+    owner = db.relationship("User", backref="timetable_events")
+    course = db.relationship("Course", backref="events")
+
+
+class Exam(db.Model):
+    __tablename__ = "exams"
+
+    id = db.Column(db.Integer, primary_key=True)
+    title = db.Column(db.String(160), nullable=False)
+    exam_date = db.Column(db.DateTime, nullable=False)
+    location = db.Column(db.String(120), nullable=True)
+    weight_percent = db.Column(db.Integer, default=0)
+    owner_id = db.Column(db.Integer, db.ForeignKey("users.id"), nullable=False)
+    course_id = db.Column(db.Integer, db.ForeignKey("courses.id"), nullable=True)
+
+    owner = db.relationship("User", backref="exams")
+    course = db.relationship("Course", backref="exams")
+
+
+class RevisionTopic(db.Model):
+    __tablename__ = "revision_topics"
+
+    id = db.Column(db.Integer, primary_key=True)
+    name = db.Column(db.String(160), nullable=False)
+    progress = db.Column(db.Integer, default=0)
+    status = db.Column(db.String(40), default="Not Started")
+    exam_id = db.Column(db.Integer, db.ForeignKey("exams.id"), nullable=False)
+
+    exam = db.relationship("Exam", backref="topics")
+
+
+class StudyGroup(db.Model):
+    __tablename__ = "study_groups"
+
+    id = db.Column(db.Integer, primary_key=True)
+    name = db.Column(db.String(120), nullable=False)
+    group_code = db.Column(db.String(40), unique=True, nullable=False)
+    description = db.Column(db.Text, nullable=True)
+
+
+class GroupMember(db.Model):
+    __tablename__ = "group_members"
+
+    id = db.Column(db.Integer, primary_key=True)
+    role = db.Column(db.String(80), default="Member")
+    status = db.Column(db.String(40), default="Online")
+    user_id = db.Column(db.Integer, db.ForeignKey("users.id"), nullable=False)
+    group_id = db.Column(db.Integer, db.ForeignKey("study_groups.id"), nullable=False)
+
+    user = db.relationship("User", backref="group_memberships")
+    group = db.relationship("StudyGroup", backref="members")
+
+
+class GroupTask(db.Model):
+    __tablename__ = "group_tasks"
+
+    id = db.Column(db.Integer, primary_key=True)
+    title = db.Column(db.String(160), nullable=False)
+    status = db.Column(db.String(40), default="Not Started")
+    due_date = db.Column(db.DateTime, nullable=True)
+    assigned_to_id = db.Column(db.Integer, db.ForeignKey("users.id"), nullable=True)
+    group_id = db.Column(db.Integer, db.ForeignKey("study_groups.id"), nullable=False)
+
+    assigned_to = db.relationship("User", backref="assigned_tasks")
+    group = db.relationship("StudyGroup", backref="tasks")
+
+
+class GroupMessage(db.Model):
+    __tablename__ = "group_messages"
+
+    id = db.Column(db.Integer, primary_key=True)
+    body = db.Column(db.Text, nullable=False)
+    created_at = db.Column(db.DateTime, default=datetime.utcnow)
+    sender_id = db.Column(db.Integer, db.ForeignKey("users.id"), nullable=False)
+    group_id = db.Column(db.Integer, db.ForeignKey("study_groups.id"), nullable=False)
+
+    sender = db.relationship("User", backref="group_messages")
+    group = db.relationship("StudyGroup", backref="messages")
+
+
+class DirectMessage(db.Model):
+    __tablename__ = "direct_messages"
+
+    id = db.Column(db.Integer, primary_key=True)
+    body = db.Column(db.Text, nullable=False)
+    is_read = db.Column(db.Boolean, default=False)
+    created_at = db.Column(db.DateTime, default=datetime.utcnow)
+    sender_id = db.Column(db.Integer, db.ForeignKey("users.id"), nullable=False)
+    receiver_id = db.Column(db.Integer, db.ForeignKey("users.id"), nullable=False)
+
+    sender = db.relationship("User", foreign_keys=[sender_id], backref="sent_messages")
+    receiver = db.relationship("User", foreign_keys=[receiver_id], backref="received_messages")
+
+
+class Reminder(db.Model):
+    __tablename__ = "reminders"
+
+    id = db.Column(db.Integer, primary_key=True)
+    title = db.Column(db.String(160), nullable=False)
+    due_at = db.Column(db.DateTime, nullable=True)
+    is_done = db.Column(db.Boolean, default=False)
+    owner_id = db.Column(db.Integer, db.ForeignKey("users.id"), nullable=False)
+
+    owner = db.relationship("User", backref="reminders")
+
+
+class HandbookSubject(db.Model):
+    __tablename__ = "handbook_subjects"
+
+    id = db.Column(db.Integer, primary_key=True)
+    code = db.Column(db.String(20), unique=True, nullable=False)
+    title = db.Column(db.String(160), nullable=False)
+    school = db.Column(db.String(160), nullable=True)
+    level = db.Column(db.String(40), nullable=True)
+    semester = db.Column(db.String(80), nullable=True)
+    credit_points = db.Column(db.Integer, default=6)

--- a/app/routes/main.py
+++ b/app/routes/main.py
@@ -1,5 +1,7 @@
 from flask import Blueprint, render_template_string
 
+from app.models import Course, Exam, GroupMessage, StudyGroup, TimetableEvent, User
+
 main_bp = Blueprint("main", __name__)
 
 
@@ -14,9 +16,53 @@ def index():
         </head>
         <body style="font-family: Arial; background:#0f172a; color:white; padding:40px;">
             <h1>StudySync Flask App Running</h1>
-            <p>The initial Flask backend setup is working.</p>
-            <p>Next step: add database models and authentication.</p>
+            <p>The Flask backend setup is working.</p>
+            <p>Stage 2 adds database models and demo seed data.</p>
+            <p><a href="/db-check" style="color:#93c5fd;">Check database demo data</a></p>
         </body>
         </html>
         """
+    )
+
+
+@main_bp.route("/db-check")
+def db_check():
+    user_count = User.query.count()
+    course_count = Course.query.count()
+    event_count = TimetableEvent.query.count()
+    exam_count = Exam.query.count()
+    group_count = StudyGroup.query.count()
+    message_count = GroupMessage.query.count()
+
+    return render_template_string(
+        """
+        <!DOCTYPE html>
+        <html>
+        <head>
+            <title>StudySync Database Check</title>
+        </head>
+        <body style="font-family: Arial; background:#0f172a; color:white; padding:40px;">
+            <h1>Database Check</h1>
+            <p>If these numbers are above 0, the database seed worked.</p>
+
+            <ul>
+                <li>Users: {{ user_count }}</li>
+                <li>Courses: {{ course_count }}</li>
+                <li>Timetable events: {{ event_count }}</li>
+                <li>Exams: {{ exam_count }}</li>
+                <li>Study groups: {{ group_count }}</li>
+                <li>Group messages: {{ message_count }}</li>
+            </ul>
+
+            <p><a href="/" style="color:#93c5fd;">Back to home</a></p>
+        </body>
+        </html>
+        """
+        ,
+        user_count=user_count,
+        course_count=course_count,
+        event_count=event_count,
+        exam_count=exam_count,
+        group_count=group_count,
+        message_count=message_count
     )

--- a/app/seed.py
+++ b/app/seed.py
@@ -1,0 +1,110 @@
+from datetime import datetime
+
+from app.extensions import db
+from app.models import User, Course, TimetableEvent, Exam, RevisionTopic, StudyGroup, GroupMember, GroupTask, GroupMessage, DirectMessage, Reminder, HandbookSubject
+
+
+def seed_demo_data():
+    existing_user = User.query.filter_by(email="you@student.uwa.edu.au").first()
+
+    if existing_user:
+        print("Demo data already exists. Skipping seed.")
+        return
+
+    jane = User(
+        full_name="Jane Smith",
+        email="you@student.uwa.edu.au",
+        uwa_id="23456789",
+        program="Master of Information Technology",
+        bio="StudySync demo user.",
+        skills="Flask, HTML, CSS, JavaScript, SQLAlchemy",
+        availability="Weekdays after 2 PM",
+        avatar_colour="purple"
+    )
+    jane.set_password("password123")
+
+    tom = User(full_name="Tom Liu", email="tom@student.uwa.edu.au", uwa_id="23112233", program="Bachelor of Computer Science", skills="Frontend, JavaScript", availability="Monday afternoon", avatar_colour="orange")
+    tom.set_password("password123")
+
+    amy = User(full_name="Amy Kim", email="amy@student.uwa.edu.au", uwa_id="23884455", program="Master of Data Science", skills="Planning, testing", availability="Tuesday evening", avatar_colour="violet")
+    amy.set_password("password123")
+
+    ryan = User(full_name="Ryan Zhang", email="ryan@student.uwa.edu.au", uwa_id="23990011", program="Master of Information Technology", skills="AI UI, testing", availability="Friday afternoon", avatar_colour="blue")
+    ryan.set_password("password123")
+
+    db.session.add_all([jane, tom, amy, ryan])
+    db.session.flush()
+
+    cits3403 = Course(code="CITS3403", title="Agile Web Development", description="Client-server web application development using Flask.", owner_id=jane.id)
+    cits4009 = Course(code="CITS4009", title="Fundamentals of Data Science", description="Data analysis and modelling.", owner_id=jane.id)
+    math2004 = Course(code="MATH2004", title="Linear Algebra", description="Matrices and vectors.", owner_id=jane.id)
+
+    db.session.add_all([cits3403, cits4009, math2004])
+    db.session.flush()
+
+    events = [
+        TimetableEvent(title="CITS3403 Laboratory", event_type="Laboratory", location="Lab 106", start_time=datetime(2026, 4, 14, 9, 0), end_time=datetime(2026, 4, 14, 10, 0), owner_id=jane.id, course_id=cits3403.id, is_group_event=True),
+        TimetableEvent(title="CITS3403 Lecture", event_type="Lecture", location="LT 225", start_time=datetime(2026, 4, 15, 9, 0), end_time=datetime(2026, 4, 15, 10, 0), owner_id=jane.id, course_id=cits3403.id),
+        TimetableEvent(title="MATH2004 Lecture", event_type="Lecture", location="LT 120", start_time=datetime(2026, 4, 16, 9, 0), end_time=datetime(2026, 4, 16, 10, 0), owner_id=jane.id, course_id=math2004.id)
+    ]
+    db.session.add_all(events)
+
+    exam = Exam(title="CITS3403 Mid-semester Test", exam_date=datetime(2026, 4, 15, 10, 0), location="Room 106", weight_percent=20, owner_id=jane.id, course_id=cits3403.id)
+    db.session.add(exam)
+    db.session.flush()
+
+    topics = [
+        RevisionTopic(name="HTML semantic elements and forms", progress=100, status="Done", exam_id=exam.id),
+        RevisionTopic(name="CSS flexbox and grid layout", progress=100, status="Done", exam_id=exam.id),
+        RevisionTopic(name="JavaScript event listeners and DOM manipulation", progress=65, status="In Progress", exam_id=exam.id),
+        RevisionTopic(name="Flask routes and Jinja templates", progress=30, status="Not Started", exam_id=exam.id),
+        RevisionTopic(name="SQLAlchemy models and relationships", progress=10, status="Not Started", exam_id=exam.id)
+    ]
+    db.session.add_all(topics)
+
+    group = StudyGroup(name="CITS3403 Group 7", group_code="GRP-3403-07", description="Group project team for StudySync.")
+    db.session.add(group)
+    db.session.flush()
+
+    members = [
+        GroupMember(user_id=jane.id, group_id=group.id, role="Lead", status="Online"),
+        GroupMember(user_id=tom.id, group_id=group.id, role="Frontend", status="Online"),
+        GroupMember(user_id=amy.id, group_id=group.id, role="Planner", status="Last seen 1h ago"),
+        GroupMember(user_id=ryan.id, group_id=group.id, role="AI UI", status="Online")
+    ]
+    db.session.add_all(members)
+
+    tasks = [
+        GroupTask(title="Login and register pages", status="Done", assigned_to_id=jane.id, group_id=group.id),
+        GroupTask(title="Timetable grid component", status="In Progress", assigned_to_id=tom.id, group_id=group.id),
+        GroupTask(title="User stories and page list document", status="Done", assigned_to_id=amy.id, group_id=group.id),
+        GroupTask(title="AI planner chat UI", status="Not Started", assigned_to_id=ryan.id, group_id=group.id)
+    ]
+    db.session.add_all(tasks)
+
+    messages = [
+        GroupMessage(body="Morning team! I uploaded the user stories for Checkpoint 2.", sender_id=amy.id, group_id=group.id),
+        GroupMessage(body="Great. I am working on the timetable UI.", sender_id=tom.id, group_id=group.id),
+        GroupMessage(body="I will connect the Flask routes and database models.", sender_id=jane.id, group_id=group.id)
+    ]
+    db.session.add_all(messages)
+
+    db.session.add(DirectMessage(body="Can you review the timetable branch later?", sender_id=tom.id, receiver_id=jane.id))
+
+    reminders = [
+        Reminder(title="Review Flask routes before demo", due_at=datetime(2026, 4, 15, 8, 30), owner_id=jane.id),
+        Reminder(title="Finish group PR review", due_at=datetime(2026, 4, 16, 17, 0), owner_id=jane.id)
+    ]
+    db.session.add_all(reminders)
+
+    subjects = [
+        HandbookSubject(code="CITS3403", title="Agile Web Development", school="Computer Science", level="Level 3", semester="Semester 1"),
+        HandbookSubject(code="CITS4009", title="Fundamentals of Data Science", school="Computer Science", level="Level 4", semester="Semester 2"),
+        HandbookSubject(code="CITS1401", title="Computational Thinking with Python", school="Computer Science", level="Level 1", semester="Semester 1"),
+        HandbookSubject(code="MATH2004", title="Linear Algebra", school="Mathematics", level="Level 2", semester="Semester 1")
+    ]
+    db.session.add_all(subjects)
+
+    db.session.commit()
+
+    print("Demo data created successfully.")


### PR DESCRIPTION
This PR adds the database layer for StudySync.

Included:
- User model with hashed password support
- Course model
- Timetable event model
- Exam and revision topic models
- Study group, group member and group task models
- Direct message and group chat message models
- Reminder model
- UWA handbook subject model
- Demo seed data
- init-db command
- /db-check route to confirm database records

Tested locally:
- Ran python -m flask --app run.py init-db
- Confirmed demo data was created successfully
- Ran the Flask server
- Confirmed /db-check displays:
  - Users: 4
  - Courses: 3
  - Timetable events: 3
  - Exams: 1
  - Study groups: 1
  - Group messages: 3