### PR TITLE
Add timetable event pages

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -4,6 +4,7 @@ from app.config import Config
 from app.extensions import csrf, db, login_manager
 from app.routes.auth import auth_bp
 from app.routes.main import main_bp
+from app.routes.timetable import timetable_bp
 
 
 def create_app():
@@ -22,11 +23,11 @@ def create_app():
         from app.models import User
         return User.query.get(int(user_id))
 
-    # Stage 3 simple auth pages are exempted from CSRF so login/register work reliably.
     csrf.exempt(auth_bp)
 
     app.register_blueprint(main_bp)
     app.register_blueprint(auth_bp)
+    app.register_blueprint(timetable_bp)
 
     @app.cli.command("init-db")
     def init_db_command():

--- a/app/routes/main.py
+++ b/app/routes/main.py
@@ -1,4 +1,4 @@
-from flask import Blueprint, render_template_string
+from flask import Blueprint, render_template, render_template_string
 from flask_login import current_user, login_required
 
 from app.models import Course, Exam, GroupMessage, StudyGroup, TimetableEvent, User
@@ -19,8 +19,13 @@ def index():
             <body style="font-family: Arial; background:#0f172a; color:white; padding:40px;">
                 <h1>Welcome back, {{ current_user.full_name }}</h1>
                 <p>You are logged in to StudySync.</p>
-                <p><a href="/dashboard" style="color:#93c5fd;">Open Dashboard</a></p>
-                <p><a href="/logout" style="color:#fca5a5;">Logout</a></p>
+                <p>
+                    <a href="/dashboard" style="color:#93c5fd;">Open Dashboard</a>
+                    |
+                    <a href="/timetable" style="color:#93c5fd;">Open Timetable</a>
+                    |
+                    <a href="/logout" style="color:#fca5a5;">Logout</a>
+                </p>
             </body>
             </html>
             """
@@ -36,6 +41,7 @@ def index():
         <body style="font-family: Arial; background:#0f172a; color:white; padding:40px;">
             <h1>StudySync Flask App Running</h1>
             <p>The Flask backend, database and authentication setup are working.</p>
+
             <p>
                 <a href="/login" style="color:#93c5fd;">Login</a>
                 |
@@ -52,27 +58,21 @@ def index():
 @main_bp.route("/dashboard")
 @login_required
 def dashboard():
-    return render_template_string(
-        """
-        <!DOCTYPE html>
-        <html>
-        <head>
-            <title>StudySync Dashboard</title>
-        </head>
-        <body style="font-family: Arial; background:#0f172a; color:white; padding:40px;">
-            <h1>Dashboard</h1>
-            <p>Hello, {{ current_user.full_name }}.</p>
-            <p>Email: {{ current_user.email }}</p>
-            <p>Program: {{ current_user.program or "Not added yet" }}</p>
-            <p>This page proves login sessions are working.</p>
-            <p>
-                <a href="/db-check" style="color:#93c5fd;">Database Check</a>
-                |
-                <a href="/logout" style="color:#fca5a5;">Logout</a>
-            </p>
-        </body>
-        </html>
-        """
+    user_count = User.query.count()
+    course_count = Course.query.count()
+    event_count = TimetableEvent.query.count()
+    exam_count = Exam.query.count()
+    group_count = StudyGroup.query.count()
+    message_count = GroupMessage.query.count()
+
+    return render_template(
+        "pages/dashboard.html",
+        user_count=user_count,
+        course_count=course_count,
+        event_count=event_count,
+        exam_count=exam_count,
+        group_count=group_count,
+        message_count=message_count,
     )
 
 
@@ -95,6 +95,7 @@ def db_check():
         <body style="font-family: Arial; background:#0f172a; color:white; padding:40px;">
             <h1>Database Check</h1>
             <p>If these numbers are above 0, the database seed worked.</p>
+
             <ul>
                 <li>Users: {{ user_count }}</li>
                 <li>Courses: {{ course_count }}</li>
@@ -103,6 +104,7 @@ def db_check():
                 <li>Study groups: {{ group_count }}</li>
                 <li>Group messages: {{ message_count }}</li>
             </ul>
+
             <p><a href="/" style="color:#93c5fd;">Back to home</a></p>
         </body>
         </html>

--- a/app/routes/timetable.py
+++ b/app/routes/timetable.py
@@ -1,0 +1,143 @@
+from datetime import date, datetime, timedelta
+
+from flask import Blueprint, flash, redirect, render_template, request, url_for
+from flask_login import current_user, login_required
+
+from app.extensions import db
+from app.models import Course, TimetableEvent
+
+timetable_bp = Blueprint("timetable", __name__)
+
+
+def get_week_start():
+    start_value = request.args.get("start")
+
+    if start_value:
+        try:
+            return datetime.strptime(start_value, "%Y-%m-%d").date()
+        except ValueError:
+            pass
+
+    return date(2026, 4, 13)
+
+
+@timetable_bp.route("/timetable")
+@login_required
+def timetable():
+    week_start = get_week_start()
+    week_end = week_start + timedelta(days=7)
+
+    events = (
+        TimetableEvent.query
+        .filter(TimetableEvent.owner_id == current_user.id)
+        .filter(TimetableEvent.start_time >= datetime.combine(week_start, datetime.min.time()))
+        .filter(TimetableEvent.start_time < datetime.combine(week_end, datetime.min.time()))
+        .order_by(TimetableEvent.start_time.asc())
+        .all()
+    )
+
+    days = []
+
+    for index in range(5):
+        current_day = week_start + timedelta(days=index)
+        day_events = [
+            event for event in events
+            if event.start_time.date() == current_day
+        ]
+
+        days.append({
+            "date": current_day,
+            "label": current_day.strftime("%A"),
+            "events": day_events,
+        })
+
+    return render_template(
+        "pages/timetable.html",
+        week_start=week_start,
+        week_end=week_end - timedelta(days=1),
+        previous_week=week_start - timedelta(days=7),
+        next_week=week_start + timedelta(days=7),
+        days=days,
+    )
+
+
+@timetable_bp.route("/timetable/events/new", methods=["GET", "POST"])
+@login_required
+def create_event():
+    courses = Course.query.filter_by(owner_id=current_user.id).order_by(Course.code.asc()).all()
+
+    if request.method == "POST":
+        title = request.form.get("title", "").strip()
+        event_type = request.form.get("event_type", "").strip()
+        location = request.form.get("location", "").strip()
+        start_time_text = request.form.get("start_time", "")
+        end_time_text = request.form.get("end_time", "")
+        course_id_text = request.form.get("course_id", "")
+
+        if not title or not event_type or not start_time_text or not end_time_text:
+            flash("Title, type, start time and end time are required.")
+            return render_template("pages/event_form.html", courses=courses)
+
+        try:
+            start_time = datetime.fromisoformat(start_time_text)
+            end_time = datetime.fromisoformat(end_time_text)
+        except ValueError:
+            flash("Please enter valid start and end times.")
+            return render_template("pages/event_form.html", courses=courses)
+
+        if end_time <= start_time:
+            flash("End time must be after start time.")
+            return render_template("pages/event_form.html", courses=courses)
+
+        course_id = None
+        if course_id_text:
+            course = Course.query.filter_by(id=int(course_id_text), owner_id=current_user.id).first()
+            if course:
+                course_id = course.id
+
+        event = TimetableEvent(
+            title=title,
+            event_type=event_type,
+            location=location,
+            start_time=start_time,
+            end_time=end_time,
+            owner_id=current_user.id,
+            course_id=course_id,
+            is_group_event=False,
+        )
+
+        db.session.add(event)
+        db.session.commit()
+
+        flash("Event created successfully.")
+        return redirect(url_for("timetable.timetable", start=start_time.date().isoformat()))
+
+    return render_template("pages/event_form.html", courses=courses)
+
+
+@timetable_bp.route("/timetable/events/<int:event_id>")
+@login_required
+def event_detail(event_id):
+    event = TimetableEvent.query.filter_by(
+        id=event_id,
+        owner_id=current_user.id
+    ).first_or_404()
+
+    return render_template("pages/event_detail.html", event=event)
+
+
+@timetable_bp.route("/timetable/events/<int:event_id>/delete", methods=["POST"])
+@login_required
+def delete_event(event_id):
+    event = TimetableEvent.query.filter_by(
+        id=event_id,
+        owner_id=current_user.id
+    ).first_or_404()
+
+    event_date = event.start_time.date()
+
+    db.session.delete(event)
+    db.session.commit()
+
+    flash("Event deleted successfully.")
+    return redirect(url_for("timetable.timetable", start=event_date.isoformat()))

--- a/app/static/css/styles.css
+++ b/app/static/css/styles.css
@@ -1,0 +1,159 @@
+body {
+    margin: 0;
+    font-family: Arial, sans-serif;
+    background: #0f172a;
+    color: white;
+}
+
+a {
+    color: #93c5fd;
+    text-decoration: none;
+}
+
+.app-shell {
+    display: flex;
+    min-height: 100vh;
+}
+
+.sidebar {
+    width: 250px;
+    background: #08111f;
+    border-right: 1px solid #243047;
+    padding: 24px;
+}
+
+.logo {
+    font-size: 26px;
+    font-weight: bold;
+    color: #8ab4ff;
+    margin-bottom: 30px;
+}
+
+.nav-link {
+    display: block;
+    padding: 12px;
+    margin-bottom: 8px;
+    border-radius: 10px;
+    color: #cbd5e1;
+}
+
+.nav-link:hover,
+.nav-link.active {
+    background: #1e3a8a;
+    color: white;
+}
+
+.main-content {
+    flex: 1;
+    padding: 36px;
+    background:
+        radial-gradient(circle at top right, rgba(124, 58, 237, 0.25), transparent 35%),
+        #0f172a;
+}
+
+.page-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    border-bottom: 1px solid #243047;
+    padding-bottom: 22px;
+    margin-bottom: 24px;
+}
+
+.btn {
+    display: inline-block;
+    padding: 11px 16px;
+    border-radius: 10px;
+    border: 1px solid #334155;
+    background: #111827;
+    color: white;
+    margin-left: 8px;
+    cursor: pointer;
+}
+
+.btn-primary {
+    background: linear-gradient(135deg, #3b82f6, #7c3aed);
+    border: none;
+}
+
+.btn-danger {
+    background: #dc2626;
+    border: none;
+}
+
+.grid {
+    display: grid;
+    gap: 18px;
+}
+
+.grid-2 {
+    grid-template-columns: repeat(2, 1fr);
+}
+
+.card {
+    background: #111827;
+    border: 1px solid #243047;
+    border-radius: 18px;
+    padding: 22px;
+}
+
+.list-item {
+    padding: 14px 0;
+    border-bottom: 1px solid #243047;
+}
+
+.muted {
+    color: #94a3b8;
+}
+
+.badge {
+    display: inline-block;
+    background: #172554;
+    color: #93c5fd;
+    padding: 5px 10px;
+    border-radius: 999px;
+    font-size: 13px;
+}
+
+label {
+    display: block;
+    margin-top: 16px;
+    margin-bottom: 6px;
+    color: #bfdbfe;
+    font-weight: bold;
+}
+
+.form-input {
+    width: 100%;
+    padding: 13px;
+    border-radius: 10px;
+    border: 1px solid #334155;
+    background: #0f172a;
+    color: white;
+}
+
+.grid-3 {
+    grid-template-columns: repeat(3, 1fr);
+}
+
+.stat-number {
+    font-size: 42px;
+    font-weight: bold;
+    margin-top: 12px;
+    margin-bottom: 8px;
+}
+
+.success-text {
+    color: #86efac;
+}
+
+.warning-text {
+    color: #facc15;
+}
+
+@media (max-width: 900px) {
+    .grid-2,
+    .grid-3 {
+        grid-template-columns: 1fr;
+    }
+}

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>{% block title %}StudySync{% endblock %}</title>
+    <link rel="stylesheet" href="{{ url_for('static', filename='css/styles.css') }}">
+</head>
+<body>
+    <div class="app-shell">
+        <aside class="sidebar">
+            <div class="logo">?? StudySync</div>
+
+            <a class="nav-link" href="/">Home</a>
+            <a class="nav-link" href="/dashboard">Dashboard</a>
+            <a class="nav-link active" href="/timetable">Timetable</a>
+            <a class="nav-link" href="/db-check">Database Check</a>
+            <a class="nav-link" href="/logout">Logout</a>
+
+            {% if current_user.is_authenticated %}
+                <p class="muted">
+                    Logged in as<br>
+                    <strong>{{ current_user.full_name }}</strong>
+                </p>
+            {% endif %}
+        </aside>
+
+        <main class="main-content">
+            {% block content %}{% endblock %}
+        </main>
+    </div>
+</body>
+</html>

--- a/app/templates/pages/dashboard.html
+++ b/app/templates/pages/dashboard.html
@@ -1,0 +1,104 @@
+{% extends "base.html" %}
+
+{% block title %}Dashboard - StudySync{% endblock %}
+
+{% block content %}
+<div class="page-header">
+    <div>
+        <h1>Dashboard</h1>
+        <p>Welcome back, {{ current_user.full_name }}. Your StudySync dashboard is connected to the database.</p>
+    </div>
+
+    <a href="/logout" class="btn btn-danger">Logout</a>
+</div>
+
+<div class="grid grid-3">
+    <div class="card">
+        <span class="badge">Courses</span>
+        <div class="stat-number">{{ course_count }}</div>
+        <div class="muted">Enrolled units stored in database</div>
+    </div>
+
+    <div class="card">
+        <span class="badge">Timetable</span>
+        <div class="stat-number">{{ event_count }}</div>
+        <div class="muted">Scheduled lectures, labs and study events</div>
+    </div>
+
+    <div class="card">
+        <span class="badge">Exams</span>
+        <div class="stat-number">{{ exam_count }}</div>
+        <div class="muted">Upcoming assessments</div>
+    </div>
+</div>
+
+<br>
+
+<div class="grid grid-2">
+    <div class="card">
+        <h2>Student Profile</h2>
+
+        <div class="list-item">
+            <strong>Name</strong>
+            <p class="muted">{{ current_user.full_name }}</p>
+        </div>
+
+        <div class="list-item">
+            <strong>Email</strong>
+            <p class="muted">{{ current_user.email }}</p>
+        </div>
+
+        <div class="list-item">
+            <strong>Program</strong>
+            <p class="muted">{{ current_user.program or "Not added yet" }}</p>
+        </div>
+    </div>
+
+    <div class="card">
+        <h2>Quick Actions</h2>
+
+        <div class="list-item">
+            <a class="btn btn-primary" href="/timetable">Open Timetable</a>
+        </div>
+
+        <div class="list-item">
+            <a class="btn btn-primary" href="/timetable/events/new">Create Event</a>
+        </div>
+
+        <div class="list-item">
+            <a class="btn" href="/db-check">Check Database</a>
+        </div>
+    </div>
+</div>
+
+<br>
+
+<div class="card">
+    <h2>Project Progress</h2>
+
+    <div class="list-item">
+        <strong class="success-text">Stage 1 Complete</strong>
+        <p class="muted">Initial Flask project structure is working.</p>
+    </div>
+
+    <div class="list-item">
+        <strong class="success-text">Stage 2 Complete</strong>
+        <p class="muted">Database models and seed data are working.</p>
+    </div>
+
+    <div class="list-item">
+        <strong class="success-text">Stage 3 Complete</strong>
+        <p class="muted">Login, register and logout flow is working.</p>
+    </div>
+
+    <div class="list-item">
+        <strong class="success-text">Stage 4 Complete</strong>
+        <p class="muted">Shared layout and dashboard styling added.</p>
+    </div>
+
+    <div class="list-item">
+        <strong class="warning-text">Stage 5 In Progress</strong>
+        <p class="muted">Timetable events are being connected.</p>
+    </div>
+</div>
+{% endblock %}

--- a/app/templates/pages/event_detail.html
+++ b/app/templates/pages/event_detail.html
@@ -1,0 +1,32 @@
+{% extends "base.html" %}
+
+{% block title %}Event Detail - StudySync{% endblock %}
+
+{% block content %}
+<div class="page-header">
+    <div>
+        <h1>{{ event.title }}</h1>
+        <p>Event details from the database.</p>
+    </div>
+
+    <a class="btn" href="/timetable?start={{ event.start_time.date().isoformat() }}">Back to Timetable</a>
+</div>
+
+<div class="card">
+    <p><strong>Type:</strong> {{ event.event_type }}</p>
+    <p><strong>Location:</strong> {{ event.location or "No location added" }}</p>
+    <p><strong>Start:</strong> {{ event.start_time.strftime("%A, %d %B %Y %I:%M %p") }}</p>
+    <p><strong>End:</strong> {{ event.end_time.strftime("%A, %d %B %Y %I:%M %p") }}</p>
+
+    {% if event.course %}
+        <p><strong>Course:</strong> {{ event.course.code }} - {{ event.course.title }}</p>
+    {% else %}
+        <p><strong>Course:</strong> Not linked to a course</p>
+    {% endif %}
+
+    <form method="POST" action="/timetable/events/{{ event.id }}/delete">
+        <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+        <button class="btn btn-danger" type="submit">Delete Event</button>
+    </form>
+</div>
+{% endblock %}

--- a/app/templates/pages/event_form.html
+++ b/app/templates/pages/event_form.html
@@ -1,0 +1,62 @@
+{% extends "base.html" %}
+
+{% block title %}Create Event - StudySync{% endblock %}
+
+{% block content %}
+<div class="page-header">
+    <div>
+        <h1>Create Event</h1>
+        <p>Add a lecture, lab, tutorial, exam or study session.</p>
+    </div>
+
+    <a class="btn" href="/timetable">Back to Timetable</a>
+</div>
+
+<div class="card">
+    {% with messages = get_flashed_messages() %}
+        {% if messages %}
+            {% for message in messages %}
+                <p class="muted">{{ message }}</p>
+            {% endfor %}
+        {% endif %}
+    {% endwith %}
+
+    <form method="POST">
+        <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+
+        <label>Title</label>
+        <input class="form-input" type="text" name="title" placeholder="CITS3403 Lecture" required>
+
+        <label>Type</label>
+        <select class="form-input" name="event_type" required>
+            <option value="Lecture">Lecture</option>
+            <option value="Laboratory">Laboratory</option>
+            <option value="Tutorial">Tutorial</option>
+            <option value="Exam">Exam</option>
+            <option value="Assignment">Assignment</option>
+            <option value="Workshop">Workshop</option>
+            <option value="Study">Study</option>
+        </select>
+
+        <label>Course</label>
+        <select class="form-input" name="course_id">
+            <option value="">No course selected</option>
+            {% for course in courses %}
+                <option value="{{ course.id }}">{{ course.code }} - {{ course.title }}</option>
+            {% endfor %}
+        </select>
+
+        <label>Location</label>
+        <input class="form-input" type="text" name="location" placeholder="Room 106">
+
+        <label>Start time</label>
+        <input class="form-input" type="datetime-local" name="start_time" required>
+
+        <label>End time</label>
+        <input class="form-input" type="datetime-local" name="end_time" required>
+
+        <br><br>
+        <button class="btn btn-primary" type="submit">Save Event</button>
+    </form>
+</div>
+{% endblock %}

--- a/app/templates/pages/timetable.html
+++ b/app/templates/pages/timetable.html
@@ -1,0 +1,48 @@
+{% extends "base.html" %}
+
+{% block title %}Timetable - StudySync{% endblock %}
+
+{% block content %}
+<div class="page-header">
+    <div>
+        <h1>Timetable</h1>
+        <p>{{ week_start.strftime("%d %b %Y") }} - {{ week_end.strftime("%d %b %Y") }}</p>
+    </div>
+
+    <div>
+        <a class="btn" href="/timetable?start={{ previous_week.isoformat() }}">? Previous Week</a>
+        <a class="btn" href="/timetable?start={{ next_week.isoformat() }}">Next Week ?</a>
+        <a class="btn btn-primary" href="/timetable/events/new">+ Create Event</a>
+    </div>
+</div>
+
+<div class="grid grid-2">
+    {% for day in days %}
+        <div class="card">
+            <h2>{{ day.label }}</h2>
+            <p class="muted">{{ day.date.strftime("%d %B %Y") }}</p>
+
+            {% if day.events %}
+                {% for event in day.events %}
+                    <a href="/timetable/events/{{ event.id }}">
+                        <div class="list-item">
+                            <strong>{{ event.title }}</strong>
+                            <p class="muted">
+                                {{ event.start_time.strftime("%I:%M %p") }}
+                                -
+                                {{ event.end_time.strftime("%I:%M %p") }}
+                            </p>
+                            <span class="badge">{{ event.event_type }}</span>
+                            {% if event.location %}
+                                <p class="muted">?? {{ event.location }}</p>
+                            {% endif %}
+                        </div>
+                    </a>
+                {% endfor %}
+            {% else %}
+                <p class="muted">No events for this day.</p>
+            {% endif %}
+        </div>
+    {% endfor %}
+</div>
+{% endblock %}


### PR DESCRIPTION
This PR adds the timetable feature for StudySync.

Included:
- Timetable page grouped by weekdays
- Previous and next week navigation
- Create event form
- Event detail page
- Delete event action
- Timetable events stored in SQLite through SQLAlchemy
- Sidebar link to timetable page
- Dashboard quick links to timetable actions

Tested locally:
- Timetable loads after login
- Previous and next week links work
- New events can be created
- Created events appear in timetable
- Event details open correctly
- Events can be deleted